### PR TITLE
Add design color palette docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Este repositório contém o projeto **VerumOverview**, plataforma para gerenciamento de produtos digitais.
 
 A estrutura principal está dentro da pasta `verumoverview` com front-end em React e back-end em Node.js/Express utilizando TypeScript.
+
+Para detalhes sobre a identidade visual e a paleta de cores utilizada no projeto, consulte o arquivo [docs/design.md](verumoverview/docs/design.md).

--- a/verumoverview/docs/design.md
+++ b/verumoverview/docs/design.md
@@ -1,0 +1,30 @@
+# Identidade Visual e Paleta de Cores
+
+A plataforma utiliza um design moderno, clean e visualmente atrativo. As interfaces sao construidas com TailwindCSS customizado conforme a seguinte paleta de cores:
+
+## Cores Base
+- **Primaria:** `#FFFFFF` (branco)
+- **Secundaria:** `#4E008E` (roxo)
+
+## Cores para Status (Semaforo)
+- **Verde:** `#00B894`
+- **Amarelo:** `#FDCB6E`
+- **Vermelho:** `#D63031`
+
+## Cores de Criticidade/Prioridade
+- **Alta:** `#E17055`
+- **Media:** `#FDCB6E`
+- **Baixa:** `#0984E3`
+
+## Cores para Indicadores e Insights
+- **Insight Positivo:** `#00CEC9`
+- **Insight Negativo:** `#D63031`
+- **Insight Neutro:** `#636E72`
+
+## Estilo Visual
+- Cantos arredondados, sombras suaves e tipografia clean.
+- Modo escuro disponivel: fundo `#1E1E2F` e texto `#FFFFFF`.
+- Transicoes suaves em estados de hover e foco.
+- Botoes primarios roxos com texto branco.
+- Botoes secundarios com borda roxa, texto roxo e fundo branco.
+- Graficos e dashboards seguem a mesma paleta para status e indicadores.


### PR DESCRIPTION
## Summary
- document VerumOverview's color palette and design recommendations
- reference the design doc in the README

## Testing
- `npm test` in `verumoverview/backend` *(fails: Missing script)*
- `npm test` in `verumoverview/frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844ce6214248321bcc9740ea9330aa3