### PR TITLE
Implement basic Atividades module

### DIFF
--- a/verumoverview/backend/src/app.ts
+++ b/verumoverview/backend/src/app.ts
@@ -6,6 +6,7 @@ import logRoutes from './routes/logRoutes';
 import logMiddleware from './middlewares/logMiddleware';
 import db from './services/db';
 import projectRoutes from './routes/projectRoutes';
+import activityRoutes from './routes/activityRoutes';
 
 const app = express();
 app.use(bodyParser.json());
@@ -14,6 +15,7 @@ app.use(logMiddleware);
 app.use('/auth', authRoutes);
 app.use('/api', protectedRoutes);
 app.use('/api/projects', projectRoutes);
+app.use('/api/atividades', activityRoutes);
 app.use('/logs', logRoutes);
 
 const PORT = process.env.PORT || 4000;

--- a/verumoverview/backend/src/controllers/ActivityController.ts
+++ b/verumoverview/backend/src/controllers/ActivityController.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from 'express';
+import db from '../services/db';
+import { Activity } from '../models/Activity';
+
+export default class ActivityController {
+  static async list(req: Request, res: Response): Promise<void> {
+    try {
+      const result = await db.query('SELECT * FROM atividades ORDER BY data_meta');
+      res.json(result.rows);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao listar atividades' });
+    }
+  }
+
+  static async get(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const result = await db.query('SELECT * FROM atividades WHERE id_atividade=$1', [id]);
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Atividade nao encontrada' });
+        return;
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao buscar atividade' });
+    }
+  }
+
+  static async create(req: Request, res: Response): Promise<void> {
+    const fields = req.body as Activity;
+    try {
+      const result = await db.query(
+        `INSERT INTO atividades(
+          id_projeto, titulo, descricao, responsavel, time, status,
+          data_meta, data_limite, horas_estimadas, horas_gastas, prioridade,
+          dependencias, anexos, historico_atualizacoes, comentarios
+        ) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING *`,
+        [
+          fields.id_projeto,
+          fields.titulo,
+          fields.descricao,
+          fields.responsavel,
+          fields.time,
+          fields.status,
+          fields.data_meta,
+          fields.data_limite,
+          fields.horas_estimadas,
+          fields.horas_gastas,
+          fields.prioridade,
+          JSON.stringify(fields.dependencias || {}),
+          JSON.stringify(fields.anexos || {}),
+          JSON.stringify(fields.historico_atualizacoes || {}),
+          JSON.stringify(fields.comentarios || {})
+        ]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao criar atividade' });
+    }
+  }
+
+  static async update(req: Request, res: Response): Promise<void> {
+    const { id } = req.params;
+    const fields = req.body as Activity;
+    const keys = Object.keys(fields);
+    const values = Object.values(fields);
+    const sets = keys.map((k, i) => `${k}=$${i + 1}`);
+    try {
+      const result = await db.query(
+        `UPDATE atividades SET ${sets.join(', ')} WHERE id_atividade=$${keys.length + 1} RETURNING *`,
+        [...values.map(v => typeof v === 'object' ? JSON.stringify(v) : v), id]
+      );
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Atividade nao encontrada' });
+        return;
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao atualizar atividade' });
+    }
+  }
+
+  static async remove(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const result = await db.query('DELETE FROM atividades WHERE id_atividade=$1 RETURNING *', [id]);
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Atividade nao encontrada' });
+        return;
+      }
+      res.json({});
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao remover atividade' });
+    }
+  }
+}

--- a/verumoverview/backend/src/db/schema.sql
+++ b/verumoverview/backend/src/db/schema.sql
@@ -53,11 +53,22 @@ CREATE TABLE projetos (
 );
 
 CREATE TABLE atividades (
-  id SERIAL PRIMARY KEY,
+  id_atividade UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id_projeto UUID REFERENCES projetos(id_projeto),
   titulo VARCHAR(255) NOT NULL,
   descricao TEXT,
-  projeto_id UUID REFERENCES projetos(id_projeto),
-  responsavel_id INTEGER REFERENCES usuarios(id),
+  responsavel INTEGER REFERENCES usuarios(id),
+  time INTEGER REFERENCES times(id),
+  status VARCHAR(50),
+  data_meta DATE,
+  data_limite DATE,
+  horas_estimadas NUMERIC,
+  horas_gastas NUMERIC,
+  prioridade VARCHAR(10),
+  dependencias JSONB,
+  anexos JSONB,
+  historico_atualizacoes JSONB,
+  comentarios JSONB,
   criado_em TIMESTAMP DEFAULT NOW()
 );
 

--- a/verumoverview/backend/src/models/Activity.ts
+++ b/verumoverview/backend/src/models/Activity.ts
@@ -1,0 +1,18 @@
+export interface Activity {
+  id_atividade?: string;
+  id_projeto?: string;
+  titulo: string;
+  descricao?: string;
+  responsavel?: number;
+  time?: number;
+  status?: string;
+  data_meta?: string;
+  data_limite?: string;
+  horas_estimadas?: number;
+  horas_gastas?: number;
+  prioridade?: string;
+  dependencias?: any;
+  anexos?: any;
+  historico_atualizacoes?: any;
+  comentarios?: any;
+}

--- a/verumoverview/backend/src/routes/activityRoutes.ts
+++ b/verumoverview/backend/src/routes/activityRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import authMiddleware from '../middlewares/authMiddleware';
+import ActivityController from '../controllers/ActivityController';
+
+const router = Router();
+router.use(authMiddleware);
+
+router.get('/', ActivityController.list);
+router.get('/:id', ActivityController.get);
+router.post('/', ActivityController.create);
+router.put('/:id', ActivityController.update);
+router.delete('/:id', ActivityController.remove);
+
+export default router;

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -1,3 +1,181 @@
+import { useEffect, useState } from 'react';
+import {
+  fetchActivities,
+  createActivity,
+  updateActivity,
+  deleteActivity
+} from '../services/activities';
+import { logAction } from '../services/logger';
+
+interface Activity {
+  id_atividade: string;
+  titulo: string;
+  status?: string;
+  data_meta?: string;
+  data_limite?: string;
+  horas_estimadas?: number;
+  horas_gastas?: number;
+  prioridade?: string;
+}
+
+const emptyActivity: Activity = {
+  id_atividade: '',
+  titulo: '',
+  status: 'Nao Iniciada',
+  data_meta: '',
+  data_limite: '',
+  horas_estimadas: 0,
+  horas_gastas: 0,
+  prioridade: 'Media'
+};
+
 export default function Atividades() {
-  return <div>Atividades</div>;
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [editing, setEditing] = useState<Activity | null>(null);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const data = await fetchActivities();
+    setActivities(data);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editing) return;
+    if (editing.id_atividade) {
+      await updateActivity(editing.id_atividade, editing);
+      logAction('update_activity', { id: editing.id_atividade });
+    } else {
+      const created = await createActivity(editing);
+      logAction('create_activity', { id: created.id_atividade });
+    }
+    setEditing(null);
+    load();
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('Excluir atividade?')) return;
+    await deleteActivity(id);
+    logAction('delete_activity', { id });
+    load();
+  }
+
+  const filtered = filter ? activities.filter(a => a.status === filter) : activities;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between">
+        <h1 className="text-xl font-bold">Atividades</h1>
+        <button className="bg-secondary text-white px-4 py-2 rounded" onClick={() => setEditing({ ...emptyActivity })}>
+          Nova Atividade
+        </button>
+      </div>
+
+      <div>
+        <label className="mr-2">Status:</label>
+        <select value={filter} onChange={e => setFilter(e.target.value)} className="border p-1">
+          <option value="">Todos</option>
+          <option>Nao Iniciada</option>
+          <option>Em Andamento</option>
+          <option>Concluida</option>
+          <option>Em Risco</option>
+          <option>Bloqueada</option>
+        </select>
+      </div>
+
+      <table className="min-w-full bg-white dark:bg-dark-background text-sm">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Título</th>
+            <th className="p-2 text-left">Status</th>
+            <th className="p-2 text-left">Meta</th>
+            <th className="p-2 text-left">Limite</th>
+            <th className="p-2 text-left">Horas</th>
+            <th className="p-2 text-left">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(a => (
+            <tr key={a.id_atividade} className="border-t">
+              <td className="p-2">{a.titulo}</td>
+              <td className="p-2">{a.status}</td>
+              <td className="p-2">{a.data_meta}</td>
+              <td className="p-2">{a.data_limite}</td>
+              <td className="p-2">{a.horas_gastas || 0}/{a.horas_estimadas}</td>
+              <td className="p-2 space-x-2">
+                <button className="text-blue-600" onClick={() => setEditing({ ...a })}>Editar</button>
+                <button className="text-red-600" onClick={() => handleDelete(a.id_atividade)}>Excluir</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {editing && (
+        <form onSubmit={handleSubmit} className="bg-white dark:bg-dark-background p-4 rounded shadow space-y-2">
+          <div>
+            <label className="block">Título</label>
+            <input type="text" className="border p-1 w-full" value={editing.titulo}
+              onChange={e => setEditing({ ...editing, titulo: e.target.value })} required />
+          </div>
+          <div>
+            <label className="block">Status</label>
+            <select className="border p-1 w-full" value={editing.status}
+              onChange={e => setEditing({ ...editing, status: e.target.value })}>
+              <option>Nao Iniciada</option>
+              <option>Em Andamento</option>
+              <option>Concluida</option>
+              <option>Em Risco</option>
+              <option>Bloqueada</option>
+            </select>
+          </div>
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <label className="block">Data Meta</label>
+              <input type="date" className="border p-1 w-full" value={editing.data_meta || ''}
+                onChange={e => setEditing({ ...editing, data_meta: e.target.value })} />
+            </div>
+            <div className="flex-1">
+              <label className="block">Data Limite</label>
+              <input type="date" className="border p-1 w-full" value={editing.data_limite || ''}
+                onChange={e => setEditing({ ...editing, data_limite: e.target.value })} />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <label className="block">Horas Estimadas</label>
+              <input type="number" className="border p-1 w-full" value={editing.horas_estimadas || 0}
+                onChange={e => setEditing({ ...editing, horas_estimadas: Number(e.target.value) })} />
+            </div>
+            <div className="flex-1">
+              <label className="block">Horas Gastas</label>
+              <input type="number" className="border p-1 w-full" value={editing.horas_gastas || 0}
+                onChange={e => setEditing({ ...editing, horas_gastas: Number(e.target.value) })} />
+            </div>
+          </div>
+          <div>
+            <label className="block">Prioridade</label>
+            <select className="border p-1 w-full" value={editing.prioridade}
+              onChange={e => setEditing({ ...editing, prioridade: e.target.value })}>
+              <option>Alta</option>
+              <option>Media</option>
+              <option>Baixa</option>
+            </select>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={() => setEditing(null)} className="border px-4 py-1 rounded">
+              Cancelar
+            </button>
+            <button type="submit" className="bg-secondary text-white px-4 py-1 rounded">
+              Salvar
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
 }

--- a/verumoverview/frontend/src/services/activities.ts
+++ b/verumoverview/frontend/src/services/activities.ts
@@ -1,0 +1,20 @@
+import api from './api';
+
+export async function fetchActivities() {
+  const res = await api.get('/api/atividades');
+  return res.data;
+}
+
+export async function createActivity(data: any) {
+  const res = await api.post('/api/atividades', data);
+  return res.data;
+}
+
+export async function updateActivity(id: string, data: any) {
+  const res = await api.put(`/api/atividades/${id}`, data);
+  return res.data;
+}
+
+export async function deleteActivity(id: string) {
+  await api.delete(`/api/atividades/${id}`);
+}


### PR DESCRIPTION
## Summary
- extend DB schema with full `atividades` table definition
- create Activity model, controller and routes
- expose `/api/atividades` API endpoints
- add frontend service for activities
- implement simple Atividades page with CRUD UI

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd ../frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844ded95d4883219e5612cad3244078