### PR TITLE
Add node_modules volume to compose

### DIFF
--- a/verumoverview/docker-compose.yml
+++ b/verumoverview/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     command: npm run dev
     volumes:
       - ./backend:/app
+      - /app/node_modules
     ports:
       - "4000:4000"
     depends_on:
@@ -33,6 +34,7 @@ services:
     command: npm start
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- persist installed dependencies via node_modules volumes for backend and frontend

## Testing
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe100b048321bfb4c82afc0b828e