### PR TITLE
Fix compose API URL

### DIFF
--- a/verumoverview/docker-compose.yml
+++ b/verumoverview/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_API_URL=http://localhost:4000
+      - REACT_APP_API_URL=http://backend:4000
     networks:
       - verum-net
 


### PR DESCRIPTION
## Summary
- update FE env var to use backend service

## Testing
- `docker-compose up -d --build` *(fails: Docker daemon couldn't start)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe285f288321bd94f467753e9986