### PR TITLE
Add db init script for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 Este repositório contém o projeto **VerumOverview**, plataforma para gerenciamento de produtos digitais.
 
 A estrutura principal está dentro da pasta `verumoverview` com front-end em React e back-end em Node.js/Express utilizando TypeScript.
+Ao executar `docker-compose up` pela primeira vez o script `verumoverview/db-init/init.sql`
+é aplicado automaticamente ao PostgreSQL.
 
 Para detalhes sobre a identidade visual e a paleta de cores utilizada no projeto, consulte o arquivo [docs/design.md](verumoverview/docs/design.md).

--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -75,6 +75,8 @@ Abrirá a aplicação em `http://localhost:3000`.
 ## Banco de Dados
 
 Ao subir com Docker Compose o PostgreSQL já será iniciado na porta `5432`. Os dados são persistidos em `db-data/`.
+No primeiro `docker-compose up` o arquivo `db-init/init.sql` será executado automaticamente
+para criar o esquema inicial do banco.
 
 Você pode acessar via `psql`:
 
@@ -86,10 +88,11 @@ Ou utilizar ferramentas como Adminer ou TablePlus apontando para `localhost:5432
 
 ## Migrações e Seeds
 
-Dentro de `backend/src/db/schema.sql` existe o esquema inicial. Você pode executá-lo manualmente caso precise recriar o banco:
+O script utilizado fica em `db-init/init.sql`. Caso precise recriar o banco manualmente
+execute-o via `psql`:
 
 ```bash
-psql -h localhost -U <usuario> -d <banco> -f backend/src/db/schema.sql
+psql -h localhost -U <usuario> -d <banco> -f db-init/init.sql
 ```
 
 ## Monitoramento de Logs

--- a/verumoverview/db-init/init.sql
+++ b/verumoverview/db-init/init.sql
@@ -1,0 +1,96 @@
+-- PostgreSQL schema for VerumOverview
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE perfis_acesso (
+  id SERIAL PRIMARY KEY,
+  nome VARCHAR(50) NOT NULL,
+  permissoes JSONB NOT NULL
+);
+
+CREATE TABLE usuarios (
+  id SERIAL PRIMARY KEY,
+  nome VARCHAR(255) NOT NULL,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  senha_hash VARCHAR(255) NOT NULL,
+  perfil_id INTEGER REFERENCES perfis_acesso(id),
+  criado_em TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE pessoas (
+  id_pessoa UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  nome_completo VARCHAR(255) NOT NULL,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  cargo_funcao VARCHAR(255),
+  time VARCHAR(255),
+  status VARCHAR(50),
+  perfil_comportamental JSONB,
+  engajamento INTEGER,
+  projetos_vinculados JSONB,
+  anexos JSONB,
+  historico_movimentacoes JSONB,
+  comentarios JSONB
+);
+
+CREATE TABLE times (
+  id_time UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  nome VARCHAR(255) NOT NULL,
+  lider INTEGER REFERENCES usuarios(id),
+  capacidade_total INTEGER,
+  membros JSONB,
+  anexos JSONB,
+  historico_alteracoes JSONB,
+  comentarios JSONB
+);
+
+CREATE TABLE projetos (
+  id_projeto UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  nome VARCHAR(255) NOT NULL,
+  codigo_projeto VARCHAR(50) UNIQUE,
+  objetivo TEXT,
+  justificativa TEXT,
+  stakeholders JSONB,
+  status VARCHAR(50),
+  data_inicio_prevista DATE,
+  data_fim_prevista DATE,
+  data_inicio_real DATE,
+  data_fim_real DATE,
+  prioridade VARCHAR(10),
+  criticidade VARCHAR(10),
+  orcamento_planejado NUMERIC,
+  orcamento_realizado NUMERIC,
+  kpis JSONB,
+  time_responsavel JSONB,
+  anexos JSONB,
+  links JSONB,
+  historico_atualizacoes JSONB,
+  comentarios JSONB,
+  percentual_concluido INTEGER DEFAULT 0
+);
+
+CREATE TABLE atividades (
+  id_atividade UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id_projeto UUID REFERENCES projetos(id_projeto),
+  titulo VARCHAR(255) NOT NULL,
+  descricao TEXT,
+  responsavel INTEGER REFERENCES usuarios(id),
+  time UUID REFERENCES times(id_time),
+  status VARCHAR(50),
+  data_meta DATE,
+  data_limite DATE,
+  horas_estimadas NUMERIC,
+  horas_gastas NUMERIC,
+  prioridade VARCHAR(10),
+  dependencias JSONB,
+  anexos JSONB,
+  historico_atualizacoes JSONB,
+  comentarios JSONB,
+  criado_em TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE logs (
+  id SERIAL PRIMARY KEY,
+  usuario_id INTEGER REFERENCES usuarios(id),
+  acao VARCHAR(255) NOT NULL,
+  detalhes JSONB,
+  criado_em TIMESTAMP DEFAULT NOW()
+);

--- a/verumoverview/docker-compose.yml
+++ b/verumoverview/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-verumoverview}
     volumes:
       - ./db-data:/var/lib/postgresql/data
+      - ./db-init:/docker-entrypoint-initdb.d
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
## Summary
- copy backend schema.sql to db-init/init.sql
- mount db-init in docker-compose so Postgres auto-loads the schema
- document automatic schema loading in README files

## Testing
- `npm test` *(fails: Missing script)*
- `docker-compose up -d` *(fails: Docker service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68450362c918832180d8b515ff3a1355