### PR TITLE
Ajuste script do frontend

### DIFF
--- a/verumoverview/frontend/package.json
+++ b/verumoverview/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "vite --port 3000"
+    "start": "vite --port 3000 --host"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Resumo
- altera script de inicio em `package.json` para expor host

## Testes
- `docker build` falhou porque o binário não está disponível no ambiente

------
https://chatgpt.com/codex/tasks/task_e_6845868320ec83218b47859741af8795