### PR TITLE
Atualiza variável do frontend

### DIFF
--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -18,6 +18,8 @@ Copie `.env.example` para `.env` dentro da pasta `frontend` e ajuste se necessá
 cp frontend/.env.example frontend/.env
 ```
 
+No arquivo `.env` defina a variável `VITE_API_URL` apontando para a URL da API, por padrão `http://localhost:4000`.
+
 ### Backend
 
 Copie `.env.example` para `.env` dentro da pasta `backend`:

--- a/verumoverview/docker-compose.yml
+++ b/verumoverview/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_API_URL=http://backend:4000
+      - VITE_API_URL=http://backend:4000
     networks:
       - verum-net
 

--- a/verumoverview/frontend/.env.example
+++ b/verumoverview/frontend/.env.example
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:4000
+VITE_API_URL=http://localhost:4000


### PR DESCRIPTION
## Notas
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Summary
- Renomeia variável de ambiente de exemplo para `VITE_API_URL`
- Ajusta `docker-compose.yml` para exportar `VITE_API_URL=http://backend:4000`
- Documenta a variável correta no README do projeto


------
https://chatgpt.com/codex/tasks/task_e_6845869a914483219ae702bcaa095af6