### PR TITLE
Remover configuracao duplicada do PostCSS

### DIFF
--- a/verumoverview/frontend/postcss.config.cjs
+++ b/verumoverview/frontend/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Resumo
- manter apenas `postcss.config.js` no frontend
- remover `postcss.config.cjs`

## Testes
- `npm` tests não se aplicam ao frontend (sem script de teste)

------
https://chatgpt.com/codex/tasks/task_e_684586a928fc8321af4e87845ccd84cc