### PR TITLE
Fix create time on empty id

### DIFF
--- a/verumoverview/frontend/src/pages/Times.tsx
+++ b/verumoverview/frontend/src/pages/Times.tsx
@@ -53,13 +53,11 @@ export default function Times() {
       membros: editing.membros
     };
     if (editing.id_time) {
-      if (editing.id_time !== '') {
-        await updateTime(editing.id_time, payload);
-        logAction('update_time', { id: editing.id_time });
-      } else {
-        const created = await createTime(payload);
-        logAction('create_time', { id: created.id_time });
-      }
+      await updateTime(editing.id_time, payload);
+      logAction('update_time', { id: editing.id_time });
+    } else {
+      const created = await createTime(payload);
+      logAction('create_time', { id: created.id_time });
     }
     setEditing(null);
     load();


### PR DESCRIPTION
## Summary
- corrigir verificacao de id_time no cadastro de times

## Testing
- `npm test` *(falhou: jest nao encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684586e0768083218b2b397c093a10f3