### PR TITLE
Inclui orientações de credenciais padrão

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ Ao executar `docker-compose up` pela primeira vez o script `verumoverview/db-ini
 é aplicado automaticamente ao PostgreSQL.
 
 Para detalhes sobre a identidade visual e a paleta de cores utilizada no projeto, consulte o arquivo [docs/design.md](verumoverview/docs/design.md).
+
+## Credenciais de Acesso
+
+Após a instalação padrão, o primeiro acesso é realizado com o usuário `admin@example.com` e a senha `password`.
+Essas credenciais estão definidas em [`backend/src/controllers/AuthController.ts`](verumoverview/backend/src/controllers/AuthController.ts).
+
+No futuro elas poderão ser configuradas por variáveis de ambiente ou outro mecanismo de configuração.
+Enquanto isso, altere manualmente o arquivo caso deseje modificar o usuário ou a senha.

--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -74,6 +74,14 @@ npm start
 
 Abrirá a aplicação em `http://localhost:3000`.
 
+## Credenciais de Acesso
+
+Após subir o ambiente, autentique-se com o usuário `admin@example.com` e senha `password`.
+Essas informações encontram-se em [`backend/src/controllers/AuthController.ts`](backend/src/controllers/AuthController.ts).
+
+Em implementações futuras essa configuração poderá ser movida para variáveis de ambiente ou outro arquivo de configuração.
+Por ora, modifique o arquivo indicado caso deseje alterar o login padrão.
+
 ## Banco de Dados
 
 Ao subir com Docker Compose o PostgreSQL já será iniciado na porta `5432`. Os dados são persistidos em `db-data/`.


### PR DESCRIPTION
## Resumo
- adiciona seção de credenciais no README principal
- adiciona seção de credenciais no guia `verumoverview/README.md`

## Testes
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68458a8da9c88321bce561b189d3d279