### PR TITLE
Configura admin padrão e autenticação via banco

### DIFF
--- a/verumoverview/backend/src/controllers/AuthController.ts
+++ b/verumoverview/backend/src/controllers/AuthController.ts
@@ -1,29 +1,38 @@
 import { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
-
-const dummyUser = {
-  id: 1,
-  email: 'admin@example.com',
-  senha_hash: bcrypt.hashSync('password', 10),
-  permissoes: ['admin']
-};
+import db from '../services/db';
 
 export default class AuthController {
   static async login(req: Request, res: Response): Promise<void> {
     const { email, senha } = req.body;
-    if (email !== dummyUser.email) {
-      res.status(401).json({ message: 'User not found' });
-      return;
+    try {
+      const result = await db.query(
+        `SELECT u.id, u.senha_hash, p.permissoes
+         FROM usuarios u
+         JOIN perfis_acesso p ON u.perfil_id = p.id
+         WHERE u.email = $1`,
+        [email]
+      );
+      if (result.rows.length === 0) {
+        res.status(401).json({ message: 'User not found' });
+        return;
+      }
+      const user = result.rows[0];
+      const valid = await bcrypt.compare(senha, user.senha_hash);
+      if (!valid) {
+        res.status(401).json({ message: 'Invalid credentials' });
+        return;
+      }
+      const token = jwt.sign(
+        { id: user.id, permissoes: user.permissoes },
+        process.env.JWT_SECRET || 'secret',
+        { expiresIn: '1h' }
+      );
+      res.json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro no login' });
     }
-    const valid = await bcrypt.compare(senha, dummyUser.senha_hash);
-    if (!valid) {
-      res.status(401).json({ message: 'Invalid credentials' });
-      return;
-    }
-    const token = jwt.sign({ id: dummyUser.id, permissoes: dummyUser.permissoes }, process.env.JWT_SECRET || 'secret', {
-      expiresIn: '1h'
-    });
-    res.json({ token });
   }
 }

--- a/verumoverview/backend/tests/activities.test.ts
+++ b/verumoverview/backend/tests/activities.test.ts
@@ -1,12 +1,16 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
 import app from '../src/app';
+import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 const mockedQuery = db.query as jest.Mock;
 
 let token: string;
 
 beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
   const res = await request(app)
     .post('/auth/login')
     .send({ email: 'admin@example.com', senha: 'password' });

--- a/verumoverview/backend/tests/auth.test.ts
+++ b/verumoverview/backend/tests/auth.test.ts
@@ -1,9 +1,15 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
+import bcrypt from 'bcrypt';
 import app from '../src/app';
+import db from '../src/services/db';
+const mockedQuery = db.query as jest.Mock;
 
 describe('Auth routes', () => {
   it('should login and return a token', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+    });
     const res = await request(app)
       .post('/auth/login')
       .send({ email: 'admin@example.com', senha: 'password' });
@@ -12,6 +18,9 @@ describe('Auth routes', () => {
   });
 
   it('should reject invalid credentials', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+    });
     const res = await request(app)
       .post('/auth/login')
       .send({ email: 'admin@example.com', senha: 'wrong' });

--- a/verumoverview/backend/tests/misc.test.ts
+++ b/verumoverview/backend/tests/misc.test.ts
@@ -1,12 +1,16 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
 import app from '../src/app';
+import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 const mockedQuery = db.query as jest.Mock;
 
 let token: string;
 
 beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
   const res = await request(app)
     .post('/auth/login')
     .send({ email: 'admin@example.com', senha: 'password' });

--- a/verumoverview/backend/tests/pessoas.test.ts
+++ b/verumoverview/backend/tests/pessoas.test.ts
@@ -1,12 +1,16 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
 import app from '../src/app';
+import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 const mockedQuery = db.query as jest.Mock;
 
 let token: string;
 
 beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
   const res = await request(app)
     .post('/auth/login')
     .send({ email: 'admin@example.com', senha: 'password' });

--- a/verumoverview/backend/tests/projects.test.ts
+++ b/verumoverview/backend/tests/projects.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
 import app from '../src/app';
+import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 
 const mockedQuery = db.query as jest.Mock;
@@ -8,6 +9,9 @@ const mockedQuery = db.query as jest.Mock;
 let token: string;
 
 beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
   const res = await request(app)
     .post('/auth/login')
     .send({ email: 'admin@example.com', senha: 'password' });

--- a/verumoverview/backend/tests/times.test.ts
+++ b/verumoverview/backend/tests/times.test.ts
@@ -1,12 +1,16 @@
 import request from 'supertest';
 jest.mock('../src/services/db');
 import app from '../src/app';
+import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 const mockedQuery = db.query as jest.Mock;
 
 let token: string;
 
 beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
   const res = await request(app)
     .post('/auth/login')
     .send({ email: 'admin@example.com', senha: 'password' });

--- a/verumoverview/db-init/init.sql
+++ b/verumoverview/db-init/init.sql
@@ -94,3 +94,12 @@ CREATE TABLE logs (
   detalhes JSONB,
   criado_em TIMESTAMP DEFAULT NOW()
 );
+
+-- Perfil administrador padrao
+INSERT INTO perfis_acesso (nome, permissoes)
+VALUES ('Administrador', '["admin"]');
+
+-- Usuario administrador padrao
+INSERT INTO usuarios (nome, email, senha_hash, perfil_id)
+VALUES ('Admin', 'admin@example.com',
+  '$2b$10$hzfKMSkIf.j4fyR29zi25uMWUGJqLPLGhwVMSENOSIvuPJBgSpun6', 1);


### PR DESCRIPTION
## Resumo
- inserção de perfil de administrador e usuário inicial no script `init.sql`
- `AuthController` passa a validar credenciais consultando o PostgreSQL
- testes atualizados com mock do banco e uso de `bcrypt`

## Testes realizados
- `npm test` em `verumoverview/backend`


------
https://chatgpt.com/codex/tasks/task_e_68458aa1212c83218ec2ffa0ba918ad8