### PR TITLE
Implementa solicitações de acesso

### DIFF
--- a/verumoverview/backend/src/controllers/AccessRequestController.ts
+++ b/verumoverview/backend/src/controllers/AccessRequestController.ts
@@ -1,0 +1,57 @@
+import { Request, Response } from 'express';
+import db from '../services/db';
+
+export default class AccessRequestController {
+  static async create(req: Request, res: Response): Promise<void> {
+    const { email } = req.body;
+    if (!email) {
+      res.status(400).json({ message: 'Email obrigatorio' });
+      return;
+    }
+    try {
+      const result = await db.query(
+        'INSERT INTO solicitacoes_acesso(email) VALUES($1) RETURNING *',
+        [email]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao registrar solicitacao' });
+    }
+  }
+
+  static async list(req: Request, res: Response): Promise<void> {
+    try {
+      const result = await db.query(
+        'SELECT * FROM solicitacoes_acesso ORDER BY criado_em DESC'
+      );
+      res.json(result.rows);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao listar solicitacoes' });
+    }
+  }
+
+  static async update(req: Request, res: Response): Promise<void> {
+    const { id } = req.params;
+    const { status } = req.body;
+    if (!['aprovado', 'rejeitado', 'pendente'].includes(status)) {
+      res.status(400).json({ message: 'Status invalido' });
+      return;
+    }
+    try {
+      const result = await db.query(
+        'UPDATE solicitacoes_acesso SET status=$1 WHERE id=$2 RETURNING *',
+        [status, id]
+      );
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Solicitacao nao encontrada' });
+        return;
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao atualizar solicitacao' });
+    }
+  }
+}

--- a/verumoverview/backend/src/db/schema.sql
+++ b/verumoverview/backend/src/db/schema.sql
@@ -94,3 +94,10 @@ CREATE TABLE logs (
   detalhes JSONB,
   criado_em TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE solicitacoes_acesso (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pendente',
+  criado_em TIMESTAMP DEFAULT NOW()
+);

--- a/verumoverview/backend/src/middlewares/permissionMiddleware.ts
+++ b/verumoverview/backend/src/middlewares/permissionMiddleware.ts
@@ -1,10 +1,11 @@
 import { Request, Response, NextFunction } from 'express';
 
 export default function permissionMiddleware(permission: string) {
-  return (req: Request, res: Response, next: NextFunction) => {
+  return (req: Request, res: Response, next: NextFunction): void => {
     const user = (req as any).user;
     if (!user || !user.permissoes?.includes(permission)) {
-      return res.status(403).json({ message: 'Insufficient permissions' });
+      res.status(403).json({ message: 'Insufficient permissions' });
+      return;
     }
     next();
   };

--- a/verumoverview/backend/src/models/AccessRequest.ts
+++ b/verumoverview/backend/src/models/AccessRequest.ts
@@ -1,0 +1,6 @@
+export interface AccessRequest {
+  id?: number;
+  email: string;
+  status?: string;
+  criado_em?: string;
+}

--- a/verumoverview/backend/src/routes/authRoutes.ts
+++ b/verumoverview/backend/src/routes/authRoutes.ts
@@ -1,6 +1,22 @@
 import { Router } from 'express';
 import AuthController from '../controllers/AuthController';
+import AccessRequestController from '../controllers/AccessRequestController';
+import authMiddleware from '../middlewares/authMiddleware';
+import permissionMiddleware from '../middlewares/permissionMiddleware';
 
 const router = Router();
 router.post('/login', AuthController.login);
+router.post('/solicitar', AccessRequestController.create);
+router.get(
+  '/solicitacoes',
+  authMiddleware,
+  permissionMiddleware('admin'),
+  AccessRequestController.list
+);
+router.put(
+  '/solicitacoes/:id',
+  authMiddleware,
+  permissionMiddleware('admin'),
+  AccessRequestController.update
+);
 export default router;

--- a/verumoverview/db-init/init.sql
+++ b/verumoverview/db-init/init.sql
@@ -94,3 +94,10 @@ CREATE TABLE logs (
   detalhes JSONB,
   criado_em TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE solicitacoes_acesso (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pendente',
+  criado_em TIMESTAMP DEFAULT NOW()
+);

--- a/verumoverview/frontend/src/App.tsx
+++ b/verumoverview/frontend/src/App.tsx
@@ -7,11 +7,13 @@ import Atividades from './pages/Atividades';
 import Pessoas from './pages/Pessoas';
 import Times from './pages/Times';
 import ControleAcesso from './pages/ControleAcesso';
+import SolicitarAcesso from './pages/SolicitarAcesso';
 
 export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/solicitar-acesso" element={<SolicitarAcesso />} />
       <Route path="/" element={<Layout />}>
         <Route index element={<Dashboard />} />
         <Route path="projetos" element={<Projetos />} />

--- a/verumoverview/frontend/src/pages/ControleAcesso.tsx
+++ b/verumoverview/frontend/src/pages/ControleAcesso.tsx
@@ -1,3 +1,69 @@
+import { useEffect, useState } from 'react';
+import { fetchSolicitacoes, atualizarSolicitacao } from '../services/accessRequests';
+import { logAction } from '../services/logger';
+
+interface Solicitacao {
+  id: number;
+  email: string;
+  status: string;
+}
+
 export default function ControleAcesso() {
-  return <div>Controle de Acesso</div>;
+  const [solicitacoes, setSolicitacoes] = useState<Solicitacao[]>([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const data = await fetchSolicitacoes();
+    setSolicitacoes(data);
+  }
+
+  async function handle(id: number, status: string) {
+    await atualizarSolicitacao(id, status);
+    logAction('update_access_request', { id, status });
+    load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Controle de Acesso</h1>
+      <table className="min-w-full bg-white dark:bg-dark-background text-sm">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Email</th>
+            <th className="p-2 text-left">Status</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {solicitacoes.map(s => (
+            <tr key={s.id} className="border-t">
+              <td className="p-2">{s.email}</td>
+              <td className="p-2">{s.status}</td>
+              <td className="p-2 space-x-2">
+                {s.status === 'pendente' && (
+                  <>
+                    <button
+                      onClick={() => handle(s.id, 'aprovado')}
+                      className="text-blue-600"
+                    >
+                      Aprovar
+                    </button>
+                    <button
+                      onClick={() => handle(s.id, 'rejeitado')}
+                      className="text-red-600"
+                    >
+                      Rejeitar
+                    </button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }

--- a/verumoverview/frontend/src/pages/Login.tsx
+++ b/verumoverview/frontend/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { useContext, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../contexts/AuthContext';
 import { logAction } from '../services/logger';
 
@@ -32,6 +33,11 @@ export default function Login() {
       <button type="submit" className="bg-blue-500 text-white px-4 py-2">
         Entrar
       </button>
+      <p className="mt-2">
+        <Link to="/solicitar-acesso" className="text-blue-600">
+          Solicitar acesso
+        </Link>
+      </p>
     </form>
   );
 }

--- a/verumoverview/frontend/src/pages/SolicitarAcesso.tsx
+++ b/verumoverview/frontend/src/pages/SolicitarAcesso.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { solicitarAcesso } from '../services/accessRequests';
+
+export default function SolicitarAcesso() {
+  const [email, setEmail] = useState('');
+  const [enviado, setEnviado] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await solicitarAcesso(email);
+    setEnviado(true);
+  }
+
+  if (enviado) {
+    return <div className="p-4">Solicitação enviada!</div>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-2">
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        className="border p-2 w-full"
+        required
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Solicitar Acesso
+      </button>
+    </form>
+  );
+}

--- a/verumoverview/frontend/src/services/accessRequests.ts
+++ b/verumoverview/frontend/src/services/accessRequests.ts
@@ -1,0 +1,16 @@
+import api from './api';
+
+export async function solicitarAcesso(email: string) {
+  const res = await api.post('/auth/solicitar', { email });
+  return res.data;
+}
+
+export async function fetchSolicitacoes() {
+  const res = await api.get('/auth/solicitacoes');
+  return res.data;
+}
+
+export async function atualizarSolicitacao(id: number, status: string) {
+  const res = await api.put(`/auth/solicitacoes/${id}`, { status });
+  return res.data;
+}


### PR DESCRIPTION
## Resumo
- cria tabela `solicitacoes_acesso`
- ajusta middleware de permissões
- adiciona controlador e rotas de solicitações
- implementa páginas de solicitação de acesso e controle no frontend

## Testes
- `npm install` e `npm test` em `verumoverview/backend`

------
https://chatgpt.com/codex/tasks/task_e_68458aacc19c83218b9900f160b55ad0