### PR TITLE
Atualiza init.sql com tabela de solicitações de acesso

### DIFF
--- a/verumoverview/db-init/init.sql
+++ b/verumoverview/db-init/init.sql
@@ -95,6 +95,13 @@ CREATE TABLE logs (
   criado_em TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE solicitacoes_acesso (
+  id SERIAL PRIMARY KEY,
+  usuario_id INTEGER REFERENCES usuarios(id),
+  status VARCHAR(50) DEFAULT 'pendente',
+  criado_em TIMESTAMP DEFAULT NOW()
+);
+
 -- Perfil administrador padrao
 INSERT INTO perfis_acesso (nome, permissoes)
 VALUES ('Administrador', '["admin"]');


### PR DESCRIPTION
## Summary
- adiciona tabela `solicitacoes_acesso`
- mantém inserções de perfil e usuário administrador

## Testing
- `npm test` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68458d85da54832199f0cd904a377bb9