### PR TITLE
Adicionar testes para solicitações de acesso

### DIFF
--- a/verumoverview/backend/src/controllers/AccessRequestController.ts
+++ b/verumoverview/backend/src/controllers/AccessRequestController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import db from '../services/db';
+
+export default class AccessRequestController {
+  static async create(req: Request, res: Response): Promise<void> {
+    const { email, nome } = req.body;
+    try {
+      const result = await db.query(
+        'INSERT INTO solicitacoes_acesso (email, nome) VALUES ($1, $2) RETURNING *',
+        [email, nome]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao solicitar acesso' });
+    }
+  }
+
+  static async list(req: Request, res: Response): Promise<void> {
+    try {
+      const result = await db.query('SELECT * FROM solicitacoes_acesso ORDER BY id');
+      res.json(result.rows);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao listar solicitacoes' });
+    }
+  }
+
+  static async update(req: Request, res: Response): Promise<void> {
+    const { id } = req.params;
+    const { status } = req.body;
+    try {
+      const result = await db.query(
+        'UPDATE solicitacoes_acesso SET status=$1 WHERE id=$2 RETURNING *',
+        [status, id]
+      );
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Solicitacao nao encontrada' });
+        return;
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao atualizar solicitacao' });
+    }
+  }
+}

--- a/verumoverview/backend/src/middlewares/permissionMiddleware.ts
+++ b/verumoverview/backend/src/middlewares/permissionMiddleware.ts
@@ -4,7 +4,8 @@ export default function permissionMiddleware(permission: string) {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = (req as any).user;
     if (!user || !user.permissoes?.includes(permission)) {
-      return res.status(403).json({ message: 'Insufficient permissions' });
+      res.status(403).json({ message: 'Insufficient permissions' });
+      return;
     }
     next();
   };

--- a/verumoverview/backend/src/routes/authRoutes.ts
+++ b/verumoverview/backend/src/routes/authRoutes.ts
@@ -1,6 +1,21 @@
 import { Router } from 'express';
 import AuthController from '../controllers/AuthController';
+import AccessRequestController from '../controllers/AccessRequestController';
+import authMiddleware from '../middlewares/authMiddleware';
+import permissionMiddleware from '../middlewares/permissionMiddleware';
 
 const router = Router();
 router.post('/login', AuthController.login);
+router.post('/solicitar', AccessRequestController.create);
+router.use('/solicitacoes', authMiddleware);
+router.get(
+  '/solicitacoes',
+  permissionMiddleware('admin'),
+  AccessRequestController.list
+);
+router.put(
+  '/solicitacoes/:id',
+  permissionMiddleware('admin'),
+  AccessRequestController.update
+);
 export default router;

--- a/verumoverview/backend/tests/accessRequests.test.ts
+++ b/verumoverview/backend/tests/accessRequests.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest';
+jest.mock('../src/services/db');
+import app from '../src/app';
+import bcrypt from 'bcrypt';
+import db from '../src/services/db';
+const mockedQuery = db.query as jest.Mock;
+
+let token: string;
+
+beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
+  const res = await request(app)
+    .post('/auth/login')
+    .send({ email: 'admin@example.com', senha: 'password' });
+  token = res.body.token;
+});
+
+afterEach(() => mockedQuery.mockReset());
+
+describe('Access request routes', () => {
+  it('should create access request', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, email: 'n@example.com', nome: 'New', status: 'pendente' }] });
+    const res = await request(app)
+      .post('/auth/solicitar')
+      .send({ email: 'n@example.com', nome: 'New' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 1, email: 'n@example.com', nome: 'New', status: 'pendente' });
+  });
+
+  it('should list access requests', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, email: 'a@example.com', nome: 'A', status: 'pendente' }] });
+    const res = await request(app)
+      .get('/auth/solicitacoes')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, email: 'a@example.com', nome: 'A', status: 'pendente' }]);
+  });
+
+  it('should update access request', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, email: 'a@example.com', nome: 'A', status: 'aprovado' }] });
+    const res = await request(app)
+      .put('/auth/solicitacoes/1')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'aprovado' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 1, email: 'a@example.com', nome: 'A', status: 'aprovado' });
+  });
+});


### PR DESCRIPTION
## Summary
- criar `AccessRequestController`
- registrar novas rotas de solicitações em `authRoutes`
- ajustar `permissionMiddleware` para compatibilidade com o Express
- adicionar `accessRequests.test.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458da4fa3c8321856b4230002dd273