### PR TITLE
Adicionar testes para solicitações de acesso

### DIFF
--- a/verumoverview/backend/src/app.ts
+++ b/verumoverview/backend/src/app.ts
@@ -9,6 +9,7 @@ import projectRoutes from './routes/projectRoutes';
 import activityRoutes from './routes/activityRoutes';
 import personRoutes from './routes/personRoutes';
 import timeRoutes from './routes/timeRoutes';
+import accessRequestRoutes from './routes/accessRequestRoutes';
 
 const app = express();
 app.use(bodyParser.json());
@@ -22,6 +23,7 @@ app.use('/api/projects', projectRoutes);
 app.use('/api/atividades', activityRoutes);
 app.use('/api/pessoas', personRoutes);
 app.use('/api/times', timeRoutes);
+app.use('/api/solicitacoes-acesso', accessRequestRoutes);
 app.use('/logs', logRoutes);
 
 const PORT = process.env.PORT || 4000;

--- a/verumoverview/backend/src/controllers/AccessRequestController.ts
+++ b/verumoverview/backend/src/controllers/AccessRequestController.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import db from '../services/db';
+import { AccessRequest } from '../models/AccessRequest';
+
+export default class AccessRequestController {
+  static async list(req: Request, res: Response): Promise<void> {
+    try {
+      const result = await db.query('SELECT * FROM solicitacoes_acesso ORDER BY id');
+      res.json(result.rows);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao listar solicitacoes' });
+    }
+  }
+
+  static async create(req: Request, res: Response): Promise<void> {
+    const { usuario_id, status } = req.body as AccessRequest;
+    try {
+      const result = await db.query(
+        'INSERT INTO solicitacoes_acesso(usuario_id, status) VALUES($1,$2) RETURNING *',
+        [usuario_id, status]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao criar solicitacao' });
+    }
+  }
+
+  static async update(req: Request, res: Response): Promise<void> {
+    const { id } = req.params;
+    const fields = req.body as AccessRequest;
+    const keys = Object.keys(fields);
+    const values = Object.values(fields);
+    const sets = keys.map((k, i) => `${k}=$${i + 1}`);
+    try {
+      const result = await db.query(
+        `UPDATE solicitacoes_acesso SET ${sets.join(', ')} WHERE id=$${keys.length + 1} RETURNING *`,
+        [...values, id]
+      );
+      if (result.rows.length === 0) {
+        res.status(404).json({ message: 'Solicitacao nao encontrada' });
+        return;
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Erro ao atualizar solicitacao' });
+    }
+  }
+}

--- a/verumoverview/backend/src/models/AccessRequest.ts
+++ b/verumoverview/backend/src/models/AccessRequest.ts
@@ -1,0 +1,6 @@
+export interface AccessRequest {
+  id?: number;
+  usuario_id: number;
+  status?: string;
+  criado_em?: string;
+}

--- a/verumoverview/backend/src/routes/accessRequestRoutes.ts
+++ b/verumoverview/backend/src/routes/accessRequestRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import authMiddleware from '../middlewares/authMiddleware';
+import AccessRequestController from '../controllers/AccessRequestController';
+
+const router = Router();
+router.use(authMiddleware);
+
+router.get('/', AccessRequestController.list);
+router.post('/', AccessRequestController.create);
+router.put('/:id', AccessRequestController.update);
+
+export default router;

--- a/verumoverview/backend/tests/accessRequests.test.ts
+++ b/verumoverview/backend/tests/accessRequests.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+jest.mock('../src/services/db');
+import app from '../src/app';
+import bcrypt from 'bcrypt';
+import db from '../src/services/db';
+const mockedQuery = db.query as jest.Mock;
+
+let token: string;
+
+beforeAll(async () => {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 1, senha_hash: bcrypt.hashSync('password', 10), permissoes: ['admin'] }]
+  });
+  const res = await request(app)
+    .post('/auth/login')
+    .send({ email: 'admin@example.com', senha: 'password' });
+  token = res.body.token;
+});
+
+afterEach(() => mockedQuery.mockReset());
+
+describe('AccessRequest routes', () => {
+  it('lists requests', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, usuario_id: 1, status: 'pendente' }] });
+    const res = await request(app)
+      .get('/api/solicitacoes-acesso')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, usuario_id: 1, status: 'pendente' }]);
+  });
+
+  it('creates request', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, usuario_id: 2, status: 'pendente' }] });
+    const res = await request(app)
+      .post('/api/solicitacoes-acesso')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ usuario_id: 2, status: 'pendente' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 2, usuario_id: 2, status: 'pendente' });
+  });
+
+  it('updates request', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, usuario_id: 2, status: 'aprovado' }] });
+    const res = await request(app)
+      .put('/api/solicitacoes-acesso/2')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'aprovado' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 2, usuario_id: 2, status: 'aprovado' });
+  });
+});


### PR DESCRIPTION
## Summary
- criar controlador e rotas para solicitações de acesso
- incluir rotas no app
- adicionar testes de criação, listagem e atualização

## Testing
- `npm test` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6845902d1d80832185a2048918e3bcb7