### PR TITLE
Atualiza README sobre dependências

### DIFF
--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -41,8 +41,9 @@ docker-compose up
 Se você modificou `docker-compose.yml`, execute `docker-compose build` para recriar as imagens com as novas configurações.
 
 ### Dependências
+
 Se aplicou o ajuste de volumes para preservar os `node_modules` dentro dos containers, `docker-compose up` instalará tudo durante o build.
-Caso contrário, mantendo os volumes atuais (`./frontend:/app` e `./backend:/app`), rode `npm install` em cada pasta localmente antes de subir os serviços.
+Caso esteja utilizando os volumes padrão (`./frontend:/app` e `./backend:/app`), execute `npm install` dentro das pastas `frontend` e `backend` **antes** de subir os serviços. A ausência desses diretórios `node_modules` provoca erros na inicialização do front-end.
 
 A aplicação React estará em `http://localhost:3000` e o backend em `http://localhost:4000`.
 


### PR DESCRIPTION
## Summary
- orienta execução de `npm install` nos diretórios `frontend` e `backend`
- alerta que a falta desses `node_modules` impede a inicialização do front-end

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b94cb5548321a07032fa7171412b