### PR TITLE
Atualiza baseURL da API

### DIFF
--- a/verumoverview/frontend/src/services/api.ts
+++ b/verumoverview/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.VITE_API_URL || 'http://localhost:4000'
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:4000'
 });
 
 export default api;


### PR DESCRIPTION
## Resumo
- ajusta `api.ts` para usar `import.meta.env.VITE_API_URL` com valor padrão

## Testes
- `npm test` (falhou em 1 teste)
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6845b94233ac83219d164c0b8514d281