### PR TITLE
Seed inicial para administrador

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este repositório contém o projeto **VerumOverview**, plataforma para gerenciam
 
 A estrutura principal está dentro da pasta `verumoverview` com front-end em React e back-end em Node.js/Express utilizando TypeScript.
 Ao executar `docker-compose up` pela primeira vez o script `verumoverview/db-init/init.sql`
-é aplicado automaticamente ao PostgreSQL.
+é aplicado automaticamente ao PostgreSQL e cria o usuário administrador padrão.
 
 Para detalhes sobre a identidade visual e a paleta de cores utilizada no projeto, consulte o arquivo [docs/design.md](verumoverview/docs/design.md).
 
@@ -15,3 +15,6 @@ Os administradores analisam essas solicitações na página **Controle de Acesso
 
 Logo após a instalação, utilize o usuário `admin@example.com` e a senha `password`
 para realizar o primeiro login. Altere esse usuário assim que possível.
+Esse cadastro é criado automaticamente pelo seed do banco de dados. Se já houver
+um banco existente, exclua-o (ou remova a pasta `db-data/`) antes de subir os
+containers para que os registros iniciais sejam recriados.

--- a/verumoverview/db-init/init.sql
+++ b/verumoverview/db-init/init.sql
@@ -101,3 +101,14 @@ CREATE TABLE solicitacoes_acesso (
   status VARCHAR(20) NOT NULL DEFAULT 'pendente',
   criado_em TIMESTAMP DEFAULT NOW()
 );
+-- Dados iniciais
+INSERT INTO perfis_acesso (nome, permissoes)
+VALUES ('Administrador', '["admin"]');
+
+INSERT INTO usuarios (nome, email, senha_hash, perfil_id)
+VALUES (
+  'Administrador',
+  'admin@example.com',
+  '$2b$10$xCUl3rLwWSr9i5VR1NML0.OnPNoC3pltXYeT45vXDqH4BhIK8a21i',
+  (SELECT id FROM perfis_acesso WHERE nome = 'Administrador')
+);


### PR DESCRIPTION
## Resumo
- cria registro de perfil Administrador com permissões `admin`
- cadastra usuário `admin@example.com` no script de seed
- atualiza README com instruções sobre a criação automática do usuário e como recriar o banco

## Testes
- `npm test` em `verumoverview/backend` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6845bcb62fdc832185e2ca894aa78426