### PR TITLE
Tratamento de erro de rede no Login

### DIFF
--- a/verumoverview/frontend/src/__tests__/login.test.tsx
+++ b/verumoverview/frontend/src/__tests__/login.test.tsx
@@ -36,7 +36,20 @@ test('exibe mensagem de erro ao receber 401', async () => {
   await userEvent.type(screen.getByPlaceholderText(/senha/i), '123');
   await userEvent.click(screen.getByRole('button', { name: /entrar/i }));
 
-  expect(await screen.findByText(/credenciais inválidas/i)).toBeInTheDocument();
+  const msgs = await screen.findAllByText(/credenciais inválidas/i);
+  expect(msgs.length).toBeGreaterThan(0);
+});
+
+test('exibe mensagem de erro de rede quando não há resposta', async () => {
+  const loginMock = jest.fn().mockRejectedValue(new Error('Network Error'));
+  renderWithProviders(<Login />, loginMock);
+
+  await userEvent.type(screen.getByPlaceholderText(/email/i), 'user@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/senha/i), '123');
+  await userEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+  const msgs = await screen.findAllByText(/erro ao conectar com o servidor/i);
+  expect(msgs.length).toBeGreaterThan(0);
 });
 
 test('redireciona para / em caso de sucesso', async () => {

--- a/verumoverview/frontend/src/pages/Login.tsx
+++ b/verumoverview/frontend/src/pages/Login.tsx
@@ -20,6 +20,8 @@ export default function Login() {
     } catch (err: any) {
       if ((err as any).response?.status === 401) {
         setErro('Credenciais inválidas');
+      } else if (!(err as any).response) {
+        setErro('Erro ao conectar com o servidor');
       } else {
         console.error(err);
       }


### PR DESCRIPTION
## Resumo
- exibe mensagem 'Erro ao conectar com o servidor' quando não há resposta
- adiciona teste para erro de rede e ajusta verificação de mensagens

## Testes
- `npm test -- --runInBand` em `verumoverview/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6845bcc0d09c8321ac5d5422aaec816b