### PR TITLE
Enable backend CORS

### DIFF
--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -29,6 +29,7 @@ cp backend/.env.example backend/.env
 ```
 
 Edite as variáveis conforme sua configuração local.
+Se precisar liberar origens diferentes da padrão para o CORS, ajuste `CORS_ORIGIN` em `.env`.
 
 ## Uso com Docker Compose
 

--- a/verumoverview/backend/.env.example
+++ b/verumoverview/backend/.env.example
@@ -1,3 +1,4 @@
 PORT=4000
 DATABASE_URL=postgresql://user:password@localhost:5432/verumoverview
 JWT_SECRET=your_secret_key
+CORS_ORIGIN=http://localhost:3000

--- a/verumoverview/backend/package-lock.json
+++ b/verumoverview/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcrypt": "^5.1.0",
         "body-parser": "^1.20.2",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
         "pg": "^8.9.0"
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
         "@types/body-parser": "^1.19.6",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.9",
@@ -1231,6 +1233,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
@@ -2247,6 +2259,19 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",

--- a/verumoverview/backend/package.json
+++ b/verumoverview/backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "pg": "^8.9.0"
@@ -22,6 +23,7 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/pg": "^8.15.4",
     "@types/supertest": "^6.0.3",
+    "@types/cors": "^2.8.19",
     "jest": "^29.7.0",
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",

--- a/verumoverview/backend/src/app.ts
+++ b/verumoverview/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import cors from 'cors';
 import authRoutes from './routes/authRoutes';
 import protectedRoutes from './routes/protectedRoutes';
 import logRoutes from './routes/logRoutes';
@@ -12,6 +13,8 @@ import timeRoutes from './routes/timeRoutes';
 import accessRequestRoutes from './routes/accessRequestRoutes';
 
 const app = express();
+const allowedOrigin = process.env.CORS_ORIGIN || 'http://localhost:3000';
+app.use(cors({ origin: allowedOrigin }));
 app.use(bodyParser.json());
 if (process.env.NODE_ENV !== 'test') {
   app.use(logMiddleware);


### PR DESCRIPTION
## Summary
- install `cors` and its typings
- configure CORS in `src/app.ts`
- allow customizing origin via `CORS_ORIGIN` env var
- document the new variable in README

## Testing
- `npm test --silent | tail -n 5` in `verumoverview/backend`
- `npm test --silent | tail -n 5` in `verumoverview/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6845c392b07c8321a19ec4a59a6a1486