### PR TITLE
Atualiza estilo dos títulos nas páginas principais

### DIFF
--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -79,7 +79,7 @@ export default function Atividades() {
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
           <BackButton />
-          <h1 className="text-xl font-bold">Atividades</h1>
+          <h1 className="text-2xl font-semibold text-secondary mb-4">Atividades</h1>
         </div>
         <button className="bg-secondary text-white px-4 py-2 rounded hover:bg-purple-700" onClick={() => setEditing({ ...emptyActivity })}>
           Nova Atividade

--- a/verumoverview/frontend/src/pages/ControleAcesso.tsx
+++ b/verumoverview/frontend/src/pages/ControleAcesso.tsx
@@ -31,7 +31,7 @@ export default function ControleAcesso() {
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <BackButton />
-        <h1 className="text-xl font-bold">Controle de Acesso</h1>
+        <h1 className="text-2xl font-semibold text-secondary mb-4">Controle de Acesso</h1>
       </div>
       <table className="min-w-full bg-white dark:bg-dark-background text-sm">
         <thead>

--- a/verumoverview/frontend/src/pages/Dashboard.tsx
+++ b/verumoverview/frontend/src/pages/Dashboard.tsx
@@ -2,10 +2,13 @@ import Card from '../components/ui/Card';
 
 export default function Dashboard() {
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <Card title="Dashboard">
-        <p className="text-sm text-gray-600 dark:text-gray-300">Bem-vindo ao VerumOverview.</p>
-      </Card>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold text-secondary mb-4">Dashboard</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card title="Dashboard">
+          <p className="text-sm text-gray-600 dark:text-gray-300">Bem-vindo ao VerumOverview.</p>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/verumoverview/frontend/src/pages/Pessoas.tsx
+++ b/verumoverview/frontend/src/pages/Pessoas.tsx
@@ -79,7 +79,7 @@ export default function Pessoas() {
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
           <BackButton />
-          <h1 className="text-xl font-bold">Pessoas</h1>
+          <h1 className="text-2xl font-semibold text-secondary mb-4">Pessoas</h1>
         </div>
         <button
           className="bg-secondary text-white px-4 py-2 rounded hover:bg-purple-700"

--- a/verumoverview/frontend/src/pages/Projetos.tsx
+++ b/verumoverview/frontend/src/pages/Projetos.tsx
@@ -107,7 +107,7 @@ export default function Projetos() {
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
           <BackButton />
-          <h1 className="text-xl font-bold">Projetos</h1>
+          <h1 className="text-2xl font-semibold text-secondary mb-4">Projetos</h1>
         </div>
         <button
           className="flex items-center gap-1 bg-secondary text-white px-4 py-2 rounded hover:bg-purple-700"

--- a/verumoverview/frontend/src/pages/Times.tsx
+++ b/verumoverview/frontend/src/pages/Times.tsx
@@ -87,7 +87,7 @@ export default function Times() {
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
           <BackButton />
-          <h1 className="text-xl font-bold">Times</h1>
+          <h1 className="text-2xl font-semibold text-secondary mb-4">Times</h1>
         </div>
         <button
           className="bg-secondary text-white px-4 py-2 rounded hover:bg-purple-700"


### PR DESCRIPTION
## Resumo
- define h1 padronizado para todas as páginas principais
- inclui margem inferior para separar o título do conteúdo

## Testes
- `npm test` no frontend
- `npm test` no backend (falhou em `projects.test.ts`)


------
https://chatgpt.com/codex/tasks/task_e_6845d111b0e48321959f8b6901f3affd