### PR TITLE
Ajusta aparência e uso do componente Table

### DIFF
--- a/verumoverview/frontend/src/components/ui/Table.tsx
+++ b/verumoverview/frontend/src/components/ui/Table.tsx
@@ -5,7 +5,7 @@ export function Table({ children }: { children: ReactNode }) {
 }
 
 export function THead({ children }: { children: ReactNode }) {
-  return <thead className="bg-secondary text-white">{children}</thead>;
+  return <thead className="bg-[#EAE0F5] text-secondary">{children}</thead>;
 }
 
 export function Th({ children }: { children: ReactNode }) {

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -7,6 +7,7 @@ import {
 } from '../services/activities';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { Table, THead, Th, Td } from '../components/ui/Table';
 
 interface Activity {
   id_atividade: string;
@@ -98,17 +99,17 @@ export default function Atividades() {
         </select>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
-          <thead>
+        <Table>
+          <THead>
             <tr>
-              <th className="p-2 text-left">Título</th>
-              <th className="p-2 text-left">Status</th>
-              <th className="p-2 text-left">Meta</th>
-              <th className="p-2 text-left">Limite</th>
-              <th className="p-2 text-left">Horas</th>
-              <th className="p-2 text-left">Ações</th>
+              <Th>Título</Th>
+              <Th>Status</Th>
+              <Th>Meta</Th>
+              <Th>Limite</Th>
+              <Th>Horas</Th>
+              <Th>Ações</Th>
             </tr>
-          </thead>
+          </THead>
           <tbody>
             {filtered.map(a => (
               <tr key={a.id_atividade} className="border-t">
@@ -124,7 +125,7 @@ export default function Atividades() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </Table>
       </div>
 
       {editing && (

--- a/verumoverview/frontend/src/pages/ControleAcesso.tsx
+++ b/verumoverview/frontend/src/pages/ControleAcesso.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { fetchSolicitacoes, atualizarSolicitacao } from '../services/accessRequests';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { Table, THead, Th, Td } from '../components/ui/Table';
 
 interface Solicitacao {
   id: number;
@@ -33,14 +34,14 @@ export default function ControleAcesso() {
         <BackButton />
         <h1 className="text-xl font-bold">Controle de Acesso</h1>
       </div>
-      <table className="min-w-full bg-white dark:bg-dark-background text-sm">
-        <thead>
+      <Table>
+        <THead>
           <tr>
-            <th className="p-2 text-left">Email</th>
-            <th className="p-2 text-left">Status</th>
+            <Th>Email</Th>
+            <Th>Status</Th>
             <th className="p-2"></th>
           </tr>
-        </thead>
+        </THead>
         <tbody>
           {solicitacoes.map(s => (
             <tr key={s.id} className="border-t">
@@ -67,7 +68,7 @@ export default function ControleAcesso() {
             </tr>
           ))}
         </tbody>
-      </table>
+      </Table>
     </div>
   );
 }

--- a/verumoverview/frontend/src/pages/Pessoas.tsx
+++ b/verumoverview/frontend/src/pages/Pessoas.tsx
@@ -7,6 +7,7 @@ import {
 } from '../services/people';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { Table, THead, Th, Td } from '../components/ui/Table';
 
 interface Person {
   id_pessoa: string;
@@ -100,18 +101,18 @@ export default function Pessoas() {
         </select>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
-          <thead>
+        <Table>
+          <THead>
             <tr>
-              <th className="p-2 text-left">Nome</th>
-              <th className="p-2 text-left">Email</th>
-              <th className="p-2 text-left">Cargo</th>
-              <th className="p-2 text-left">Time</th>
-              <th className="p-2 text-left">Status</th>
-              <th className="p-2 text-left">Engajamento</th>
-              <th className="p-2 text-left">Ações</th>
+              <Th>Nome</Th>
+              <Th>Email</Th>
+              <Th>Cargo</Th>
+              <Th>Time</Th>
+              <Th>Status</Th>
+              <Th>Engajamento</Th>
+              <Th>Ações</Th>
             </tr>
-          </thead>
+          </THead>
           <tbody>
             {filtered.map(p => (
               <tr key={p.id_pessoa} className="border-t">
@@ -128,7 +129,7 @@ export default function Pessoas() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </Table>
       </div>
 
       {editing && (

--- a/verumoverview/frontend/src/pages/Projetos.tsx
+++ b/verumoverview/frontend/src/pages/Projetos.tsx
@@ -9,6 +9,7 @@ import {
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
 import Modal from '../components/Modal';
+import { Table, THead, Th, Td } from '../components/ui/Table';
 import { ArrowUpDown, Plus, Trash, Pencil } from 'lucide-react';
 
 interface Project {
@@ -130,9 +131,9 @@ export default function Projetos() {
         </select>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
-          <thead>
-            <tr className="bg-gray-100 dark:bg-dark-background">
+        <Table>
+          <THead>
+            <tr>
               <th className="p-2 text-left cursor-pointer" onClick={() => toggleSort('nome')}>
                 Nome <ArrowUpDown className="inline w-4 h-4" />
               </th>
@@ -158,14 +159,14 @@ export default function Projetos() {
               <th className="p-1"><input className="border p-1 rounded w-full" value={filters.fim} onChange={e => setFilters({ ...filters, fim: e.target.value })} /></th>
               <th></th>
             </tr>
-          </thead>
+          </THead>
           <tbody>
             {sorted.map(p => (
               <tr key={p.id_projeto} className="border-t">
                 <td className="p-2">{p.nome}</td>
                 <td className="p-2">{p.codigo_projeto}</td>
                 <td className="p-2">
-                  <span className="px-2 py-1 rounded bg-gray-100 text-xs">{p.status}</span>
+                  <span className="px-2 py-1 rounded text-xs">{p.status}</span>
                 </td>
                 <td className="p-2">{p.data_inicio_prevista}</td>
                 <td className="p-2">{p.data_fim_prevista}</td>
@@ -180,7 +181,7 @@ export default function Projetos() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </Table>
       </div>
 
       <Modal isOpen={!!editing} title={editing?.id_projeto ? 'Editar Projeto' : 'Novo Projeto'} onClose={() => setEditing(null)}>

--- a/verumoverview/frontend/src/pages/Times.tsx
+++ b/verumoverview/frontend/src/pages/Times.tsx
@@ -3,6 +3,7 @@ import { fetchTimes, createTime, updateTime, deleteTime } from '../services/time
 import { fetchPeople } from '../services/people';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { Table, THead, Th, Td } from '../components/ui/Table';
 
 interface Time {
   id_time: string;
@@ -107,16 +108,16 @@ export default function Times() {
         />
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
-          <thead>
+        <Table>
+          <THead>
             <tr>
-              <th className="p-2 text-left">Nome</th>
-              <th className="p-2 text-left">Líder</th>
-              <th className="p-2 text-left">Capacidade</th>
-              <th className="p-2 text-left">Membros</th>
-              <th className="p-2 text-left">Ações</th>
+              <Th>Nome</Th>
+              <Th>Líder</Th>
+              <Th>Capacidade</Th>
+              <Th>Membros</Th>
+              <Th>Ações</Th>
             </tr>
-          </thead>
+          </THead>
           <tbody>
             {filtered.map(t => (
               <tr key={t.id_time} className="border-t">
@@ -131,7 +132,7 @@ export default function Times() {
               </tr>
             ))}
           </tbody>
-        </table>
+        </Table>
       </div>
 
       {editing && (


### PR DESCRIPTION
## Resumo
- atualiza `THead` para usar fundo `#EAE0F5` e texto roxo
- aplica o componente `Table` em todas as páginas com tabelas
- remove cor fixa `bg-gray-100`

## Testes
- `npm test` em `verumoverview/frontend` *(falhou: jest not found)*
- `npm test` em `verumoverview/backend` *(falhou: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d10b87988321a0bdf13be5c6da3e