### PR TITLE
Ajustes visuais em navbar e sidebar

### DIFF
--- a/verumoverview/frontend/src/components/Navbar.tsx
+++ b/verumoverview/frontend/src/components/Navbar.tsx
@@ -40,21 +40,36 @@ export default function Navbar({ onMenuToggle }: { onMenuToggle: () => void }) {
   return (
     <header className="flex items-center justify-between bg-primary dark:bg-dark-background px-4 h-14 shadow">
       <div className="flex items-center gap-4">
-        <button onClick={onMenuToggle} aria-label="Menu" className="md:hidden">
-          <Menu />
+        <button
+          onClick={onMenuToggle}
+          aria-label="Menu"
+          className="md:hidden p-2 text-secondary focus:outline-none focus:ring-2 focus:ring-secondary rounded"
+        >
+          <Menu size={24} />
         </button>
         <span className="font-bold text-secondary">VerumOverview</span>
         <Breadcrumbs />
       </div>
       <div className="flex items-center gap-4">
-        <button onClick={() => { toggleDark(); logAction('toggle_dark'); }} aria-label="Alternar tema" className="focus:outline-none focus:ring-2 focus:ring-secondary rounded">
-          {darkMode ? <Sun /> : <Moon />}
+        <button
+          onClick={() => {
+            toggleDark();
+            logAction('toggle_dark');
+          }}
+          aria-label="Alternar tema"
+          className="p-2 text-secondary focus:outline-none focus:ring-2 focus:ring-secondary rounded"
+        >
+          {darkMode ? <Sun size={24} /> : <Moon size={24} />}
         </button>
         <Bell aria-hidden="true" className="opacity-50" />
         <div className="relative group">
-          <UserCircle aria-hidden="true" />
+          <div className="rounded-full border-2 border-secondary p-0.5 cursor-pointer">
+            <UserCircle aria-hidden="true" className="text-secondary" />
+          </div>
           <div className="absolute right-0 mt-2 hidden group-hover:block bg-white dark:bg-gray-800 border rounded shadow">
-            <button onClick={handleLogout} className="block px-4 py-2 text-sm w-full text-left">Sair</button>
+            <Link to="/perfil" className="block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700">Meu Perfil</Link>
+            <span className="block px-4 py-2 text-sm text-gray-400">Configurações Futuras</span>
+            <button onClick={handleLogout} className="block px-4 py-2 text-sm w-full text-left hover:bg-gray-100 dark:hover:bg-gray-700">Sair</button>
           </div>
         </div>
       </div>

--- a/verumoverview/frontend/src/components/Sidebar.tsx
+++ b/verumoverview/frontend/src/components/Sidebar.tsx
@@ -8,7 +8,9 @@ import {
   ListChecks,
   Users,
   Users2,
-  Shield
+  Shield,
+  ChevronLeft,
+  ChevronRight
 } from 'lucide-react';
 
 interface MenuItem {
@@ -19,12 +21,12 @@ interface MenuItem {
 }
 
 const items: MenuItem[] = [
-  { path: '/dashboard', label: 'Dashboard', icon: <Home size={20} />, roles: ['admin','gerente','timeleader','colaborador'] },
-  { path: '/projetos', label: 'Projetos', icon: <FolderKanban size={20} />, roles: ['admin','gerente','timeleader','colaborador'] },
-  { path: '/atividades', label: 'Atividades', icon: <ListChecks size={20} />, roles: ['admin','gerente','timeleader','colaborador'] },
-  { path: '/pessoas', label: 'Pessoas', icon: <Users size={20} />, roles: ['admin','gerente'] },
-  { path: '/times', label: 'Times', icon: <Users2 size={20} />, roles: ['admin','gerente','timeleader'] },
-  { path: '/controle-acesso', label: 'Controle de Acesso', icon: <Shield size={20} />, roles: ['admin'] },
+  { path: '/dashboard', label: 'Dashboard', icon: <Home size={24} />, roles: ['admin','gerente','timeleader','colaborador'] },
+  { path: '/projetos', label: 'Projetos', icon: <FolderKanban size={24} />, roles: ['admin','gerente','timeleader','colaborador'] },
+  { path: '/atividades', label: 'Atividades', icon: <ListChecks size={24} />, roles: ['admin','gerente','timeleader','colaborador'] },
+  { path: '/pessoas', label: 'Pessoas', icon: <Users size={24} />, roles: ['admin','gerente'] },
+  { path: '/times', label: 'Times', icon: <Users2 size={24} />, roles: ['admin','gerente','timeleader'] },
+  { path: '/controle-acesso', label: 'Controle de Acesso', icon: <Shield size={24} />, roles: ['admin'] },
 ];
 
 export default function Sidebar({ open, setOpen }: { open: boolean; setOpen: (v: boolean) => void; }) {
@@ -40,10 +42,16 @@ export default function Sidebar({ open, setOpen }: { open: boolean; setOpen: (v:
   };
 
   return (
-    <aside className={`bg-secondary text-white ${open ? 'w-56' : 'w-0 md:w-14'} transition-all duration-200 flex flex-col overflow-hidden`}
-      aria-label="Menu lateral">
-      <button onClick={() => setOpen(!open)} aria-label="Alternar menu" className="p-2 focus:outline-none focus:ring-2 focus:ring-white">
-        {open ? '<' : '>'}
+    <aside
+      className={`bg-secondary text-white ${open ? 'w-56' : 'w-14'} transition-all duration-200 flex flex-col overflow-hidden`}
+      aria-label="Menu lateral"
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        aria-label="Alternar menu"
+        className="p-2 focus:outline-none focus:ring-2 focus:ring-white"
+      >
+        {open ? <ChevronLeft size={20} /> : <ChevronRight size={20} />}
       </button>
       <nav className="flex-1">
         {items.filter(allowed).map(item => (
@@ -52,7 +60,9 @@ export default function Sidebar({ open, setOpen }: { open: boolean; setOpen: (v:
             to={item.path}
             onClick={() => handleClick(item.label)}
             className={({ isActive }) =>
-              `flex items-center gap-2 p-2 hover:bg-purple-700 ${isActive ? 'bg-purple-800' : ''}`
+              `flex items-center gap-2 p-3 rounded-md transition-colors ${
+                isActive ? 'bg-[#EAE0F5] text-secondary' : 'hover:bg-[#EAE0F5]'
+              }`
             }
           >
             {item.icon}


### PR DESCRIPTION
## Resumo
- atualiza estilos da Sidebar com ícones maiores e estado ativo
- permite colapso exibindo apenas ícones
- melhora a Navbar com opções de usuário e botões no padrão do design system

## Testes
- `npm test --silent` em `verumoverview/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6845d11c7528832196d9693b00074116