### PR TITLE
Implement Badge component and apply to status columns

### DIFF
--- a/verumoverview/frontend/src/components/ui/Badge.tsx
+++ b/verumoverview/frontend/src/components/ui/Badge.tsx
@@ -1,29 +1,54 @@
 interface BadgeProps {
-  color:
-    | 'verde'
-    | 'amarelo'
-    | 'vermelho'
-    | 'alta'
-    | 'media'
-    | 'baixa'
-    | 'positivo'
-    | 'negativo'
-    | 'neutro';
-  text: string;
+  variant: 'status' | 'prioridade' | 'indicador';
+  value: string;
 }
 
-const map: Record<BadgeProps['color'], string> = {
-  verde: 'bg-status-verde text-white',
-  amarelo: 'bg-status-amarelo text-black',
-  vermelho: 'bg-status-vermelho text-white',
-  alta: 'bg-prioridade-alta text-white',
-  media: 'bg-prioridade-media text-black',
-  baixa: 'bg-prioridade-baixa text-white',
-  positivo: 'bg-indicador-positivo text-white',
-  negativo: 'bg-indicador-negativo text-white',
-  neutro: 'bg-indicador-neutro text-white'
-};
+const styles = {
+  status: {
+    verde: 'bg-status-verde text-white',
+    amarelo: 'bg-status-amarelo text-black',
+    vermelho: 'bg-status-vermelho text-white'
+  },
+  prioridade: {
+    alta: 'bg-prioridade-alta text-white',
+    media: 'bg-prioridade-media text-black',
+    baixa: 'bg-prioridade-baixa text-white'
+  },
+  indicador: {
+    positivo: 'bg-indicador-positivo text-white',
+    negativo: 'bg-indicador-negativo text-white',
+    neutro: 'bg-indicador-neutro text-white'
+  }
+} as const;
 
-export default function Badge({ color, text }: BadgeProps) {
-  return <span className={`px-2 py-1 rounded text-xs ${map[color]}`}>{text}</span>;
+type StatusColor = keyof typeof styles.status;
+
+function getStatusColor(value: string): StatusColor {
+  switch (value) {
+    case 'Concluida':
+    case 'Ativo':
+    case 'Acompanhamento':
+    case 'Handoff':
+    case 'Sustentação':
+      return 'verde';
+    case 'Em Risco':
+    case 'Bloqueada':
+    case 'Desligado':
+      return 'vermelho';
+    default:
+      return 'amarelo';
+  }
+}
+
+export default function Badge({ variant, value }: BadgeProps) {
+  let colorClass = '';
+  if (variant === 'status') {
+    colorClass = styles.status[getStatusColor(value)];
+  } else if (variant === 'prioridade') {
+    colorClass = styles.prioridade[value as keyof typeof styles.prioridade];
+  } else {
+    colorClass = styles.indicador[value as keyof typeof styles.indicador];
+  }
+
+  return <span className={`px-2 py-1 rounded text-xs ${colorClass}`}>{value}</span>;
 }

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -7,6 +7,7 @@ import {
 } from '../services/activities';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import Badge from '../components/ui/Badge';
 
 interface Activity {
   id_atividade: string;
@@ -113,7 +114,9 @@ export default function Atividades() {
             {filtered.map(a => (
               <tr key={a.id_atividade} className="border-t">
                 <td className="p-2">{a.titulo}</td>
-                <td className="p-2">{a.status}</td>
+                <td className="p-2">
+                  <Badge variant="status" value={a.status || ''} />
+                </td>
                 <td className="p-2">{a.data_meta}</td>
                 <td className="p-2">{a.data_limite}</td>
                 <td className="p-2">{a.horas_gastas || 0}/{a.horas_estimadas}</td>

--- a/verumoverview/frontend/src/pages/Pessoas.tsx
+++ b/verumoverview/frontend/src/pages/Pessoas.tsx
@@ -7,6 +7,7 @@ import {
 } from '../services/people';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import Badge from '../components/ui/Badge';
 
 interface Person {
   id_pessoa: string;
@@ -119,7 +120,9 @@ export default function Pessoas() {
                 <td className="p-2">{p.email}</td>
                 <td className="p-2">{p.cargo_funcao}</td>
                 <td className="p-2">{p.time}</td>
-                <td className="p-2">{p.status}</td>
+                <td className="p-2">
+                  <Badge variant="status" value={p.status || ''} />
+                </td>
                 <td className="p-2">{p.engajamento}</td>
                 <td className="p-2 space-x-2">
                   <button aria-label="Editar" className="text-blue-600" onClick={() => setEditing({ ...p })}>Editar</button>

--- a/verumoverview/frontend/src/pages/Projetos.tsx
+++ b/verumoverview/frontend/src/pages/Projetos.tsx
@@ -9,6 +9,7 @@ import {
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
 import Modal from '../components/Modal';
+import Badge from '../components/ui/Badge';
 import { ArrowUpDown, Plus, Trash, Pencil } from 'lucide-react';
 
 interface Project {
@@ -165,7 +166,7 @@ export default function Projetos() {
                 <td className="p-2">{p.nome}</td>
                 <td className="p-2">{p.codigo_projeto}</td>
                 <td className="p-2">
-                  <span className="px-2 py-1 rounded bg-gray-100 text-xs">{p.status}</span>
+                  <Badge variant="status" value={p.status || ''} />
                 </td>
                 <td className="p-2">{p.data_inicio_prevista}</td>
                 <td className="p-2">{p.data_fim_prevista}</td>


### PR DESCRIPTION
## Summary
- criar componente `Badge` com variantes de status, prioridade e indicador
- aplicar `<Badge>` às colunas de status em Projetos, Atividades e Pessoas

## Testing
- `npm test` em `frontend`
- `npm test` em `backend` *(falha em `projects.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_6845d12388608321b40b219dad3b9d8a