### PR TITLE
Adicionar componentes Toast e Skeleton

### DIFF
--- a/verumoverview/frontend/src/components/ui/Skeleton.tsx
+++ b/verumoverview/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,9 @@
+interface SkeletonProps {
+  className?: string;
+}
+
+export default function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`}></div>
+  );
+}

--- a/verumoverview/frontend/src/components/ui/Toast.tsx
+++ b/verumoverview/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+}
+
+export default function Toast({ message, onClose }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <div className="bg-secondary text-white px-4 py-2 rounded shadow toast-show">
+      {message}
+    </div>
+  );
+}

--- a/verumoverview/frontend/src/contexts/ToastContext.tsx
+++ b/verumoverview/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, ReactNode, useCallback, useState } from 'react';
+import Toast from '../components/ui/Toast';
+
+interface ToastData { id: number; text: string; }
+
+interface ToastContextData {
+  showToast: (text: string) => void;
+}
+
+export const ToastContext = createContext<ToastContextData>({
+  showToast: () => {}
+});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const showToast = useCallback((text: string) => {
+    const id = Date.now();
+    setToasts(prev => [...prev, { id, text }]);
+  }, []);
+
+  const remove = (id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map(t => (
+          <Toast key={t.id} message={t.text} onClose={() => remove(t.id)} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/verumoverview/frontend/src/index.css
+++ b/verumoverview/frontend/src/index.css
@@ -10,3 +10,12 @@
     @apply border-red-600 focus:ring-red-600;
   }
 }
+
+@keyframes toast-in {
+  from { transform: translateY(1rem); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.toast-show {
+  animation: toast-in 0.3s ease-out;
+}

--- a/verumoverview/frontend/src/main.tsx
+++ b/verumoverview/frontend/src/main.tsx
@@ -4,15 +4,18 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { ToastProvider } from './contexts/ToastContext';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AuthProvider>
       <ThemeProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <ToastProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </ToastProvider>
       </ThemeProvider>
     </AuthProvider>
   </React.StrictMode>

--- a/verumoverview/frontend/src/pages/ControleAcesso.tsx
+++ b/verumoverview/frontend/src/pages/ControleAcesso.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { fetchSolicitacoes, atualizarSolicitacao } from '../services/accessRequests';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { ToastContext } from '../contexts/ToastContext';
+import Skeleton from '../components/ui/Skeleton';
 
 interface Solicitacao {
   id: number;
@@ -11,6 +13,8 @@ interface Solicitacao {
 
 export default function ControleAcesso() {
   const [solicitacoes, setSolicitacoes] = useState<Solicitacao[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { showToast } = useContext(ToastContext);
 
   useEffect(() => {
     load();
@@ -19,11 +23,13 @@ export default function ControleAcesso() {
   async function load() {
     const data = await fetchSolicitacoes();
     setSolicitacoes(data);
+    setLoading(false);
   }
 
   async function handle(id: number, status: string) {
     await atualizarSolicitacao(id, status);
     logAction('update_access_request', { id, status });
+    showToast('Solicitação atualizada');
     load();
   }
 
@@ -33,41 +39,45 @@ export default function ControleAcesso() {
         <BackButton />
         <h1 className="text-xl font-bold">Controle de Acesso</h1>
       </div>
-      <table className="min-w-full bg-white dark:bg-dark-background text-sm">
-        <thead>
-          <tr>
-            <th className="p-2 text-left">Email</th>
-            <th className="p-2 text-left">Status</th>
-            <th className="p-2"></th>
-          </tr>
-        </thead>
-        <tbody>
-          {solicitacoes.map(s => (
-            <tr key={s.id} className="border-t">
-              <td className="p-2">{s.email}</td>
-              <td className="p-2">{s.status}</td>
-              <td className="p-2 space-x-2">
-                {s.status === 'pendente' && (
-                  <>
-                    <button
-                      onClick={() => handle(s.id, 'aprovado')}
-                      className="text-blue-600"
-                    >
-                      Aprovar
-                    </button>
-                    <button
-                      onClick={() => handle(s.id, 'rejeitado')}
-                      className="text-red-600"
-                    >
-                      Rejeitar
-                    </button>
-                  </>
-                )}
-              </td>
+      {loading ? (
+        <Skeleton className="h-40 w-full" />
+      ) : (
+        <table className="min-w-full bg-white dark:bg-dark-background text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Email</th>
+              <th className="p-2 text-left">Status</th>
+              <th className="p-2"></th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {solicitacoes.map(s => (
+              <tr key={s.id} className="border-t">
+                <td className="p-2">{s.email}</td>
+                <td className="p-2">{s.status}</td>
+                <td className="p-2 space-x-2">
+                  {s.status === 'pendente' && (
+                    <>
+                      <button
+                        onClick={() => handle(s.id, 'aprovado')}
+                        className="text-blue-600"
+                      >
+                        Aprovar
+                      </button>
+                      <button
+                        onClick={() => handle(s.id, 'rejeitado')}
+                        className="text-red-600"
+                      >
+                        Rejeitar
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/verumoverview/frontend/src/pages/Times.tsx
+++ b/verumoverview/frontend/src/pages/Times.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { fetchTimes, createTime, updateTime, deleteTime } from '../services/times';
 import { fetchPeople } from '../services/people';
 import { logAction } from '../services/logger';
 import BackButton from '../components/BackButton';
+import { ToastContext } from '../contexts/ToastContext';
+import Skeleton from '../components/ui/Skeleton';
 
 interface Time {
   id_time: string;
@@ -31,10 +33,11 @@ export default function Times() {
   const [editing, setEditing] = useState<Time | null>(null);
   const [filter, setFilter] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const { showToast } = useContext(ToastContext);
 
   useEffect(() => {
-    load();
-    loadPeople();
+    Promise.all([load(), loadPeople()]).then(() => setLoading(false));
   }, []);
 
   async function load() {
@@ -63,9 +66,11 @@ export default function Times() {
     if (editing.id_time) {
       await updateTime(editing.id_time, payload);
       logAction('update_time', { id: editing.id_time });
+      showToast('Time atualizado com sucesso');
     } else {
       const created = await createTime(payload);
       logAction('create_time', { id: created.id_time });
+      showToast('Time criado com sucesso');
     }
     setEditing(null);
     load();
@@ -75,6 +80,7 @@ export default function Times() {
     if (!confirm('Excluir time?')) return;
     await deleteTime(id);
     logAction('delete_time', { id });
+    showToast('Time excluído com sucesso');
     load();
   }
 
@@ -107,31 +113,35 @@ export default function Times() {
         />
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
-          <thead>
-            <tr>
-              <th className="p-2 text-left">Nome</th>
-              <th className="p-2 text-left">Líder</th>
-              <th className="p-2 text-left">Capacidade</th>
-              <th className="p-2 text-left">Membros</th>
-              <th className="p-2 text-left">Ações</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map(t => (
-              <tr key={t.id_time} className="border-t">
-                <td className="p-2">{t.nome}</td>
-                <td className="p-2">{people.find(p => p.id_pessoa === String(t.lider))?.nome_completo || ''}</td>
-                <td className="p-2">{t.capacidade_total}</td>
-                <td className="p-2">{t.membros?.length || 0}</td>
-                <td className="p-2 space-x-2">
-                  <button aria-label="Editar" className="text-blue-600" onClick={() => setEditing({ ...t })}>Editar</button>
-                  <button aria-label="Excluir" className="text-red-600" onClick={() => handleDelete(t.id_time)}>Excluir</button>
-                </td>
+        {loading ? (
+          <Skeleton className="h-60 w-full" />
+        ) : (
+          <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
+            <thead>
+              <tr>
+                <th className="p-2 text-left">Nome</th>
+                <th className="p-2 text-left">Líder</th>
+                <th className="p-2 text-left">Capacidade</th>
+                <th className="p-2 text-left">Membros</th>
+                <th className="p-2 text-left">Ações</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filtered.map(t => (
+                <tr key={t.id_time} className="border-t">
+                  <td className="p-2">{t.nome}</td>
+                  <td className="p-2">{people.find(p => p.id_pessoa === String(t.lider))?.nome_completo || ''}</td>
+                  <td className="p-2">{t.capacidade_total}</td>
+                  <td className="p-2">{t.membros?.length || 0}</td>
+                  <td className="p-2 space-x-2">
+                    <button aria-label="Editar" className="text-blue-600" onClick={() => setEditing({ ...t })}>Editar</button>
+                    <button aria-label="Excluir" className="text-red-600" onClick={() => handleDelete(t.id_time)}>Excluir</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
 
       {editing && (


### PR DESCRIPTION
## Resumo
- criar componentes Toast e Skeleton na UI
- exibir toasts em ações de CRUD
- mostrar skeletons durante carregamento das listas

## Testes
- `npm test` no frontend passou
- `npm test` no backend apresentou falha em `projects.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6845d129ac4c8321a4c55bbb2e6e0214