### PR TITLE
Correção de tags em Projetos

### DIFF
--- a/verumoverview/frontend/src/pages/Projetos.tsx
+++ b/verumoverview/frontend/src/pages/Projetos.tsx
@@ -144,9 +144,6 @@ export default function Projetos() {
           <table className="min-w-full bg-white dark:bg-dark-background text-sm rounded shadow">
             <thead>
               <tr className="bg-gray-100 dark:bg-dark-background">
-        <Table>
-          <THead>
-            <tr>
               <th className="p-2 text-left cursor-pointer" onClick={() => toggleSort('nome')}>
                 Nome <ArrowUpDown className="inline w-4 h-4" />
               </th>
@@ -196,7 +193,7 @@ export default function Projetos() {
               </th>
               <th></th>
             </tr>
-          </THead>
+          </thead>
           <tbody>
             {sorted.map(p => (
               <tr key={p.id_projeto} className="border-t">


### PR DESCRIPTION
## Resumo
Corrigido erro de sintaxe em `Projetos.tsx` que impedia o build do frontend via `docker-compose`. A tag `Table` e o componente `THead` estavam abertos sem fechamento correto, resultando em falhas do esbuild. As linhas foram ajustadas removendo os componentes indevidos e adicionando o fechamento apropriado de `<thead>`.

## Testes
- `npm test` em `verumoverview/frontend` (falhou por `jest` ausente).


------
https://chatgpt.com/codex/tasks/task_e_6845d55630bc8321b9ea0101155085bc