### PR TITLE
Implementação de design tokens no frontend

### DIFF
--- a/verumoverview/frontend/src/constants/design-tokens.js
+++ b/verumoverview/frontend/src/constants/design-tokens.js
@@ -1,0 +1,70 @@
+const designTokens = {
+  colors: {
+    primary: '#4E008E',
+    primaryLight: '#EAE0F5',
+    primaryDark: '#3A0066',
+    white: '#FFFFFF',
+    status: {
+      success: '#00B894',
+      warning: '#FDCB6E',
+      error: '#D63031'
+    },
+    priority: {
+      high: '#E17055',
+      medium: '#FDCB6E',
+      low: '#0984E3'
+    },
+    indicators: {
+      positive: '#00CEC9',
+      negative: '#D63031',
+      neutral: '#636E72'
+    },
+    dark: {
+      background: '#1E1E2F',
+      card: '#2A2A3D',
+      text: '#FFFFFF'
+    },
+    gray: {
+      light: '#F1F1F1',
+      medium: '#A0A0A0',
+      border: '#E5E5E5'
+    }
+  },
+  typography: {
+    fonts: ['Inter', 'Open Sans', 'Roboto', 'sans-serif'],
+    sizes: {
+      h1: '24px',
+      h2: '18px',
+      h3: '16px',
+      base: '14px',
+      large: '16px'
+    },
+    weights: {
+      regular: '400',
+      medium: '500',
+      semibold: '600'
+    }
+  },
+  spacing: {
+    xs: '4px',
+    sm: '8px',
+    md: '16px',
+    lg: '24px',
+    xl: '32px'
+  },
+  borderRadius: {
+    small: '4px',
+    medium: '6px',
+    large: '10px'
+  },
+  shadows: {
+    light: '0 2px 8px rgba(0, 0, 0, 0.1)',
+    medium: '0 4px 16px rgba(0, 0, 0, 0.15)'
+  },
+  transitions: {
+    fast: '200ms',
+    medium: '300ms'
+  }
+};
+
+export default designTokens;

--- a/verumoverview/frontend/tailwind.config.js
+++ b/verumoverview/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+import designTokens from './src/constants/design-tokens.js';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
@@ -5,30 +7,18 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#FFFFFF',
-        secondary: '#4E008E',
-        status: {
-          verde: '#00B894',
-          amarelo: '#FDCB6E',
-          vermelho: '#D63031'
-        },
-        prioridade: {
-          alta: '#E17055',
-          media: '#FDCB6E',
-          baixa: '#0984E3'
-        },
-        indicador: {
-          positivo: '#00CEC9',
-          negativo: '#D63031',
-          neutro: '#636E72'
-        },
-        dark: {
-          background: '#1E1E2F',
-          text: '#FFFFFF'
-        }
+        primary: designTokens.colors.primary,
+        primaryLight: designTokens.colors.primaryLight,
+        primaryDark: designTokens.colors.primaryDark,
+        white: designTokens.colors.white,
+        status: designTokens.colors.status,
+        priority: designTokens.colors.priority,
+        indicators: designTokens.colors.indicators,
+        dark: designTokens.colors.dark,
+        gray: designTokens.colors.gray
       },
       fontFamily: {
-        sans: ['Inter', 'sans-serif']
+        sans: designTokens.typography.fonts
       }
     }
   },


### PR DESCRIPTION
## Resumo
- cria arquivo `design-tokens.js` centralizando variáveis de estilo
- ajusta `tailwind.config.js` para importar os tokens e expor cores e fontes

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845db45f16c832193b5aba1d53ab4e5