### PR TITLE
Corrige imports de logger

### DIFF
--- a/verumoverview/frontend/src/components/layout/Navbar.tsx
+++ b/verumoverview/frontend/src/components/layout/Navbar.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { ThemeContext } from '../../hooks/ThemeContext';
 import { AuthContext } from '../../hooks/AuthContext';
 import { useLocation, Link } from 'react-router-dom';
-import { logAction } from '../services/logger';
+import { logAction } from '../../services/logger';
 import { Sun, Moon, Bell, UserCircle, Menu } from 'lucide-react';
 
 function Breadcrumbs() {

--- a/verumoverview/frontend/src/components/layout/Sidebar.tsx
+++ b/verumoverview/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { NavLink } from 'react-router-dom';
 import { AuthContext } from '../../hooks/AuthContext';
-import { logAction } from '../services/logger';
+import { logAction } from '../../services/logger';
 import {
   Home,
   FolderKanban,


### PR DESCRIPTION
## Resumo
- ajusta caminho do logger na `Navbar` e `Sidebar`

## Testes
- `npm test --silent` em `verumoverview/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6845dd823a58832181cb939f90e29628