### PR TITLE
Implementa Card premium

### DIFF
--- a/verumoverview/frontend/src/components/ui/Card.tsx
+++ b/verumoverview/frontend/src/components/ui/Card.tsx
@@ -1,21 +1,83 @@
-import { ReactNode } from 'react';
+import { ReactNode, HTMLAttributes } from 'react';
 
-interface CardProps {
+export interface CardHeaderProps {
   title?: string;
-  actions?: ReactNode;
-  children: ReactNode;
+  subtitle?: string;
+  action?: ReactNode;
 }
 
-export default function Card({ title, actions, children }: CardProps) {
+export function CardHeader({ title, subtitle, action }: CardHeaderProps) {
+  if (!title && !subtitle && !action) return null;
+
   return (
-    <div className="bg-white dark:bg-dark-background rounded shadow p-4 space-y-2">
-      {(title || actions) && (
-        <div className="flex justify-between items-center mb-2">
-          {title && <h2 className="text-lg font-semibold">{title}</h2>}
-          {actions}
-        </div>
+    <div className="flex justify-between items-start mb-2">
+      <div>
+        {title && (
+          <h3 className="text-lg font-semibold text-primary dark:text-white">
+            {title}
+          </h3>
+        )}
+        {subtitle && (
+          <p className="text-sm text-gray-medium dark:text-gray-light">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {action && <div className="ml-2">{action}</div>}
+    </div>
+  );
+}
+
+export function CardContent({ children }: { children: ReactNode }) {
+  return <div className="py-2">{children}</div>;
+}
+
+export function CardFooter({ children }: { children: ReactNode }) {
+  return <div className="pt-2 mt-2 border-t dark:border-dark-background">{children}</div>;
+}
+
+type Variant = 'default' | 'highlighted' | 'success' | 'warning' | 'error';
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  title?: string;
+  subtitle?: string;
+  headerAction?: ReactNode;
+  variant?: Variant;
+}
+
+export default function Card({
+  title,
+  subtitle,
+  children,
+  className = '',
+  headerAction,
+  variant = 'default',
+  ...props
+}: CardProps) {
+  const variantClasses: Record<Variant, string> = {
+    default: '',
+    highlighted: 'border border-primary dark:border-primary',
+    success: 'border border-status-success dark:border-status-success',
+    warning: 'border border-status-warning dark:border-status-warning',
+    error: 'border border-status-error dark:border-status-error'
+  };
+
+  const clickable = props.onClick ? 'cursor-pointer' : '';
+
+  return (
+    <div
+      className={`bg-white dark:bg-dark-card rounded-[10px] shadow transition-shadow duration-200 hover:shadow-md ${variantClasses[variant]} ${clickable} ${className}`}
+      {...props}
+    >
+      {(title || subtitle || headerAction) && (
+        <CardHeader title={title} subtitle={subtitle} action={headerAction} />
       )}
       {children}
     </div>
   );
 }
+
+Card.Header = CardHeader;
+Card.Content = CardContent;
+Card.Footer = CardFooter;
+


### PR DESCRIPTION
## Resumo
- cria cabeçalho, conteúdo e rodapé do Card
- adiciona suporte a variantes e dark mode
- aplica efeitos de hover e cursor

## Testes
- `npm test` em `verumoverview/frontend`
- `npm test` em `verumoverview/backend`


------
https://chatgpt.com/codex/tasks/task_e_6845deeb30348321bfd34f37c7c82aee