### PR TITLE
Add premium Button and corporate Input components

### DIFF
--- a/verumoverview/frontend/src/components/ui/Button.jsx
+++ b/verumoverview/frontend/src/components/ui/Button.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import designTokens from '../../constants/design-tokens';
+
+const VARIANTS = {
+  primary: 'bg-primary text-white hover:bg-primaryDark focus:ring-primary dark:hover:bg-primaryDark',
+  secondary:
+    'bg-white text-primary border-2 border-primary hover:bg-primaryLight focus:ring-primary dark:bg-dark-card dark:text-white dark:border-primary dark:hover:bg-dark-background',
+  disabled: 'bg-gray-light text-gray-medium cursor-not-allowed',
+};
+
+const SIZES = {
+  small: 'px-4 py-2 text-sm',
+  medium: 'px-6 py-3 text-base',
+  large: 'px-8 py-4 text-lg',
+};
+
+const Button = ({ variant = 'primary', size = 'medium', children, loading = false, disabled = false, className = '', ...props }) => {
+  const isDisabled = disabled || loading || variant === 'disabled';
+  const variantStyles = VARIANTS[variant] || VARIANTS.primary;
+  const sizeStyles = SIZES[size] || SIZES.medium;
+
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-md focus:outline-none focus:ring-2 transition-colors duration-200 active:scale-95 ${variantStyles} ${sizeStyles} ${isDisabled ? VARIANTS.disabled : ''} ${className}`}
+      disabled={isDisabled}
+      {...props}
+    >
+      {loading ? (
+        <>
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          Carregando...
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  );
+};
+
+export default Button;

--- a/verumoverview/frontend/src/components/ui/Input.jsx
+++ b/verumoverview/frontend/src/components/ui/Input.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { X, Check } from 'lucide-react';
+
+const Input = ({
+  label,
+  type = 'text',
+  placeholder = '',
+  error,
+  success,
+  required = false,
+  disabled = false,
+  leftIcon,
+  options = [],
+  className = '',
+  ...props
+}) => {
+  const baseStyles = `w-full border rounded-md py-2 px-3 placeholder-gray-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary`;
+  const stateStyles = error
+    ? 'border-status-error pr-10'
+    : success
+    ? 'border-status-success pr-10'
+    : 'border-gray-border';
+  const disabledStyles = disabled
+    ? 'bg-gray-100 text-gray-medium cursor-not-allowed'
+    : 'bg-white dark:bg-dark-background dark:text-white';
+  const paddingLeft = leftIcon ? 'pl-10' : '';
+
+  const inputClasses = `${baseStyles} ${stateStyles} ${disabledStyles} ${paddingLeft} ${className}`;
+
+  const renderField = () => {
+    if (type === 'textarea') {
+      return <textarea className={inputClasses} placeholder={placeholder} disabled={disabled} {...props} />;
+    }
+    if (type === 'select') {
+      return (
+        <select className={inputClasses} disabled={disabled} {...props}>
+          <option value="" disabled hidden>
+            {placeholder}
+          </option>
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      );
+    }
+    return <input type={type} className={inputClasses} placeholder={placeholder} disabled={disabled} {...props} />;
+  };
+
+  return (
+    <label className="block text-sm text-primary dark:text-white space-y-1">
+      {label && (
+        <span>
+          {label} {required && <span className="text-status-error">*</span>}
+        </span>
+      )}
+      <div className="relative">
+        {leftIcon && <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-medium">{leftIcon}</span>}
+        {renderField()}
+        {error && <X className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-status-error" />}
+        {!error && success && <Check className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-status-success" />}
+      </div>
+      {error && <p className="text-status-error text-sm">{error}</p>}
+      {success && !error && <p className="text-status-success text-sm">{success}</p>}
+    </label>
+  );
+};
+
+export default Input;


### PR DESCRIPTION
## Summary
- implement `Button.jsx` with variants, sizes, loading state and dark mode
- implement `Input.jsx` with labels, validation and variants for textarea/select

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845dedc4c648321b2a31bc46d82ed89