### PR TITLE
Atualiza modelo e testes de solicitacoes de acesso

### DIFF
--- a/verumoverview/backend/src/controllers/AccessRequestController.ts
+++ b/verumoverview/backend/src/controllers/AccessRequestController.ts
@@ -14,11 +14,11 @@ export default class AccessRequestController {
   }
 
   static async create(req: Request, res: Response): Promise<void> {
-    const { usuario_id, status } = req.body as AccessRequest;
+    const { email, status } = req.body as AccessRequest;
     try {
       const result = await db.query(
-        'INSERT INTO solicitacoes_acesso(usuario_id, status) VALUES($1,$2) RETURNING *',
-        [usuario_id, status]
+        'INSERT INTO solicitacoes_acesso(email, status) VALUES($1,$2) RETURNING *',
+        [email, status]
       );
       res.status(201).json(result.rows[0]);
     } catch (err) {

--- a/verumoverview/backend/src/models/AccessRequest.ts
+++ b/verumoverview/backend/src/models/AccessRequest.ts
@@ -1,6 +1,6 @@
 export interface AccessRequest {
   id?: number;
-  usuario_id: number;
+  email: string;
   status?: string;
   criado_em?: string;
 }

--- a/verumoverview/backend/tests/accessRequests.test.ts
+++ b/verumoverview/backend/tests/accessRequests.test.ts
@@ -20,31 +20,31 @@ beforeAll(async () => {
 afterEach(() => mockedQuery.mockReset());
 describe('AccessRequest routes', () => {
   it('lists requests', async () => {
-    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, usuario_id: 1, status: 'pendente' }] });
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 1, email: 'user1@example.com', status: 'pendente' }] });
     const res = await request(app)
       .get('/api/solicitacoes-acesso')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ id: 1, usuario_id: 1, status: 'pendente' }]);
+    expect(res.body).toEqual([{ id: 1, email: 'user1@example.com', status: 'pendente' }]);
   });
 
   it('creates request', async () => {
-    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, usuario_id: 2, status: 'pendente' }] });
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, email: 'user2@example.com', status: 'pendente' }] });
     const res = await request(app)
       .post('/api/solicitacoes-acesso')
       .set('Authorization', `Bearer ${token}`)
-      .send({ usuario_id: 2, status: 'pendente' });
+      .send({ email: 'user2@example.com', status: 'pendente' });
     expect(res.status).toBe(201);
-    expect(res.body).toEqual({ id: 2, usuario_id: 2, status: 'pendente' });
+    expect(res.body).toEqual({ id: 2, email: 'user2@example.com', status: 'pendente' });
   });
 
   it('updates request', async () => {
-    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, usuario_id: 2, status: 'aprovado' }] });
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 2, email: 'user2@example.com', status: 'aprovado' }] });
     const res = await request(app)
       .put('/api/solicitacoes-acesso/2')
       .set('Authorization', `Bearer ${token}`)
       .send({ status: 'aprovado' });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ id: 2, usuario_id: 2, status: 'aprovado' });
+    expect(res.body).toEqual({ id: 2, email: 'user2@example.com', status: 'aprovado' });
   });
 });


### PR DESCRIPTION
## Descrição
- altera modelo `AccessRequest` para usar campo `email`
- ajusta inserção de solicitações de acesso no controller
- refatora testes de solicitações de acesso para novo formato

## Testes
- `npm test --prefix backend` (falha em `projects.test.ts`, demais passando)

------
https://chatgpt.com/codex/tasks/task_e_6845e3e765f88321b44926df1cb02a2d