### PR TITLE
Atualiza opção de conteúdo do Tailwind

### DIFF
--- a/verumoverview/frontend/tailwind.config.js
+++ b/verumoverview/frontend/tailwind.config.js
@@ -2,7 +2,7 @@ import designTokens from './src/constants/design-tokens.js';
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx}'],
   darkMode: 'class',
   theme: {
     extend: {


### PR DESCRIPTION
## Resumo
- inclui arquivos .jsx no `content` do Tailwind

## Testes
- `npm test`
- `npm run build` *(falha: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_6845e86c838c83218b2790a83a7f0ef7