### PR TITLE
Refatora App para usar ThemeContext

### DIFF
--- a/verumoverview/frontend/src/App.jsx
+++ b/verumoverview/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 import {
   LayoutDashboard, Briefcase, Users, BarChart2, Sun, Moon, Bell,
 } from 'lucide-react';
@@ -6,6 +6,7 @@ import {
   LineChart, Line, ResponsiveContainer, Tooltip, CartesianGrid, XAxis, YAxis,
   BarChart, Bar,
 } from 'recharts';
+import { ThemeContext } from './hooks/ThemeContext';
 
 const metrics = [
   { title: 'Receita Mensal', value: 'R$ 120k', icon: BarChart2, change: 12 },
@@ -29,11 +30,10 @@ const projects = [
 ];
 
 export default function App() {
-  const [dark, setDark] = useState(false);
+  const { darkMode, toggleDark } = useContext(ThemeContext);
 
   return (
-    <div className={dark ? 'dark' : ''}>
-      <div className="flex min-h-screen bg-[#F8FAFC] dark:bg-gray-900 text-gray-800 dark:text-white transition-colors duration-300">
+    <div className="flex min-h-screen bg-[#F8FAFC] dark:bg-gray-900 text-gray-800 dark:text-white transition-colors duration-300">
         {/* Sidebar */}
         <aside className="hidden md:flex md:flex-col w-64 p-6 space-y-6" style={{ background: 'linear-gradient(180deg, #4E008E 0%, #6B46C1 100%)' }}>
           <div className="text-white text-2xl font-semibold flex items-center space-x-2">
@@ -52,11 +52,11 @@ export default function App() {
             ))}
           </nav>
           <button
-            onClick={() => setDark(!dark)}
+            onClick={toggleDark}
             className="flex items-center justify-center text-white space-x-2 py-2 rounded-lg bg-white/10 hover:bg-white/20 transition"
           >
-            {dark ? <Sun size={20} /> : <Moon size={20} />}
-            <span>{dark ? 'Light' : 'Dark'}</span>
+            {darkMode ? <Sun size={20} /> : <Moon size={20} />}
+            <span>{darkMode ? 'Light' : 'Dark'}</span>
           </button>
         </aside>
 
@@ -160,6 +160,5 @@ export default function App() {
           </main>
         </div>
       </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Resumo
- remover estado local de tema em `App.jsx`
- utilizar `ThemeContext` para ler e alternar modo escuro
- manter classe `dark` aplicada em `<html>` via contexto

## Testes
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e89a97408321979091d09937b43c