### PR TITLE
Implementação utilitário de datas

### DIFF
--- a/verumoverview/frontend/src/__tests__/date.test.ts
+++ b/verumoverview/frontend/src/__tests__/date.test.ts
@@ -1,0 +1,10 @@
+import { formatDate, formatDateTime } from '../utils/date';
+
+test('formata apenas a data corretamente', () => {
+  expect(formatDate('2023-01-15')).toBe('15/01/2023');
+});
+
+test('formata data e hora em São Paulo', () => {
+  const res = formatDateTime('2023-01-01T12:00:00Z');
+  expect(res).toBe('01/01/2023 09:00');
+});

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -13,6 +13,7 @@ import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Badge from '../components/ui/Badge';
 import { Table, THead, Th, Td } from '../components/ui/Table';
+import { formatDate } from '../utils/date';
 
 interface Activity {
   id_atividade: string;
@@ -131,8 +132,8 @@ export default function Atividades() {
                   <td className="p-2">
                     <Badge variant="status" value={a.status || ''} />
                   </td>
-                  <td className="p-2">{a.data_meta}</td>
-                  <td className="p-2">{a.data_limite}</td>
+                  <td className="p-2">{a.data_meta ? formatDate(a.data_meta) : ''}</td>
+                  <td className="p-2">{a.data_limite ? formatDate(a.data_limite) : ''}</td>
                   <td className="p-2">{a.horas_gastas || 0}/{a.horas_estimadas}</td>
                   <td className="p-2 space-x-2">
                     <button aria-label="Editar" className="text-blue-600" onClick={() => setEditing({ ...a })}>Editar</button>

--- a/verumoverview/frontend/src/pages/Dashboard.tsx
+++ b/verumoverview/frontend/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import Button from '../components/ui/Button';
 import Badge from '../components/ui/Badge';
 import Skeleton from '../components/ui/Skeleton';
 import { Table, THead, Th, Td } from '../components/ui/Table';
+import { formatDateTime, formatDate } from '../utils/date';
 import {
   fetchMetrics,
   fetchRecentActivities,
@@ -126,7 +127,7 @@ export default function Dashboard() {
               </button>
             ))}
           </div>
-          <span className="text-sm text-gray-medium">Última atualização: {lastUpdate.toLocaleDateString()} {lastUpdate.toLocaleTimeString()}</span>
+          <span className="text-sm text-gray-medium">Última atualização: {formatDateTime(lastUpdate)}</span>
           <Button onClick={refresh} className="flex items-center gap-1">
             <RefreshCw size={16} /> Atualizar Dados
           </Button>
@@ -259,7 +260,7 @@ export default function Dashboard() {
                         {a.status}
                       </Badge>
                     </Td>
-                    <Td>{a.date}</Td>
+                    <Td>{formatDate(a.date)}</Td>
                   </tr>
                 ))}
               </tbody>

--- a/verumoverview/frontend/src/pages/Logs.tsx
+++ b/verumoverview/frontend/src/pages/Logs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchLogs } from '../services/auditLogs';
+import { formatDateTime } from '../utils/date';
 import BackButton from '../components/modules/BackButton';
 import Skeleton from '../components/ui/Skeleton';
 import { Table, THead, Th } from '../components/ui/Table';
@@ -49,7 +50,7 @@ export default function Logs() {
                 <tr key={l.id} className="border-t">
                   <td className="p-2">{l.email || l.usuario_id}</td>
                   <td className="p-2">{l.acao}</td>
-                  <td className="p-2">{new Date(l.criado_em).toLocaleString()}</td>
+                  <td className="p-2">{formatDateTime(l.criado_em)}</td>
                 </tr>
               ))}
             </tbody>

--- a/verumoverview/frontend/src/pages/Projetos.tsx
+++ b/verumoverview/frontend/src/pages/Projetos.tsx
@@ -15,6 +15,7 @@ import Badge from '../components/ui/Badge';
 import { ArrowUpDown, Plus, Trash, Pencil } from 'lucide-react';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import { formatDate } from '../utils/date';
 
 interface Project {
   id_projeto: string;
@@ -202,8 +203,8 @@ export default function Projetos() {
                 <td className="p-2">
                   <Badge variant="status" value={p.status || ''} />
                 </td>
-                <td className="p-2">{p.data_inicio_prevista}</td>
-                <td className="p-2">{p.data_fim_prevista}</td>
+                <td className="p-2">{p.data_inicio_prevista ? formatDate(p.data_inicio_prevista) : ''}</td>
+                <td className="p-2">{p.data_fim_prevista ? formatDate(p.data_fim_prevista) : ''}</td>
                 <td className="p-2 space-x-2">
                   <button aria-label="Editar" className="text-blue-600 inline-flex items-center" onClick={() => setEditing({ ...p })}>
                     <Pencil size={14} className="mr-1" />Editar

--- a/verumoverview/frontend/src/utils/date.ts
+++ b/verumoverview/frontend/src/utils/date.ts
@@ -1,0 +1,22 @@
+type DateOptions = Intl.DateTimeFormatOptions & {
+  dateStyle?: 'full' | 'long' | 'medium' | 'short';
+  timeStyle?: 'full' | 'long' | 'medium' | 'short';
+};
+
+export function formatDate(
+  date: string | number | Date,
+  options: DateOptions = { dateStyle: 'short' }
+) {
+  if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    date = new Date(`${date}T00:00:00-03:00`);
+  }
+  const formatted = new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
+    ...options
+  }).format(new Date(date));
+  return formatted.replace(',', '');
+}
+
+export function formatDateTime(date: string | number | Date) {
+  return formatDate(date, { dateStyle: 'short', timeStyle: 'short' });
+}


### PR DESCRIPTION
## Resumo
- cria `formatDate` e `formatDateTime` em `utils/date.ts`
- aplica formatação nas páginas de Logs, Projetos, Atividades e Dashboard
- adiciona testes unitários para a nova função

## Testes
- `npm test` em `verumoverview/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6845f737d01483219c835ce1fc27a40d