### PR TITLE
Implementação de controle de tempo

### DIFF
--- a/verumoverview/backend/src/controllers/ActivityController.ts
+++ b/verumoverview/backend/src/controllers/ActivityController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import db from '../services/db';
 import { Activity } from '../models/Activity';
+import { toMinutes } from '../utils/time';
 
 export default class ActivityController {
   static async list(req: Request, res: Response): Promise<void> {
@@ -30,6 +31,12 @@ export default class ActivityController {
 
   static async create(req: Request, res: Response): Promise<void> {
     const fields = req.body as Activity;
+    if (typeof fields.horas_estimadas === 'string') {
+      fields.horas_estimadas = toMinutes(fields.horas_estimadas);
+    }
+    if (typeof fields.horas_gastas === 'string') {
+      fields.horas_gastas = toMinutes(fields.horas_gastas);
+    }
     try {
       const result = await db.query(
         `INSERT INTO atividades(
@@ -65,6 +72,12 @@ export default class ActivityController {
   static async update(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
     const fields = req.body as Activity;
+    if (typeof fields.horas_estimadas === 'string') {
+      fields.horas_estimadas = toMinutes(fields.horas_estimadas);
+    }
+    if (typeof fields.horas_gastas === 'string') {
+      fields.horas_gastas = toMinutes(fields.horas_gastas);
+    }
     const keys = Object.keys(fields);
     const values = Object.values(fields);
     const sets = keys.map((k, i) => `${k}=$${i + 1}`);

--- a/verumoverview/backend/src/controllers/ProjectController.ts
+++ b/verumoverview/backend/src/controllers/ProjectController.ts
@@ -31,9 +31,13 @@ export default class ProjectController {
   static async create(req: Request, res: Response): Promise<void> {
     const { nome } = req.body as Project;
     try {
+      const codeRes = await db.query(
+        'SELECT COALESCE(MAX(CAST(codigo_projeto AS INTEGER)),0) + 1 AS code FROM projetos'
+      );
+      const codigo = codeRes.rows[0].code;
       const result = await db.query(
-        'INSERT INTO projetos(nome) VALUES($1) RETURNING id_projeto, nome',
-        [nome]
+        'INSERT INTO projetos(codigo_projeto, nome) VALUES($1,$2) RETURNING id_projeto, nome',
+        [codigo, nome]
       );
       res.status(201).json(result.rows[0]);
     } catch (err) {

--- a/verumoverview/backend/src/models/Activity.ts
+++ b/verumoverview/backend/src/models/Activity.ts
@@ -8,6 +8,9 @@ export interface Activity {
   status?: string;
   data_meta?: string;
   data_limite?: string;
+  /**
+   * Valores em minutos para padronizar o armazenamento de durações
+   */
   horas_estimadas?: number;
   horas_gastas?: number;
   prioridade?: string;

--- a/verumoverview/backend/src/utils/time.ts
+++ b/verumoverview/backend/src/utils/time.ts
@@ -1,0 +1,23 @@
+export function toMinutes(time: string): number {
+  if (!time) return 0;
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+export function fromMinutes(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(m)}`;
+}
+
+export function diffIndicator(
+  estimado: number,
+  gasto: number
+): 'green' | 'yellow' | 'red' {
+  if (estimado === 0) return 'green';
+  const ratio = gasto / estimado;
+  if (ratio <= 1) return 'green';
+  if (ratio <= 1.2) return 'yellow';
+  return 'red';
+}

--- a/verumoverview/backend/tests/activities.test.ts
+++ b/verumoverview/backend/tests/activities.test.ts
@@ -4,6 +4,7 @@ import app from '../src/app';
 import bcrypt from 'bcrypt';
 import db from '../src/services/db';
 const mockedQuery = db.query as jest.Mock;
+import { toMinutes, fromMinutes, diffIndicator } from '../src/utils/time';
 
 let token: string;
 
@@ -56,5 +57,21 @@ describe('Activity routes', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({});
+  });
+});
+
+describe('time utils', () => {
+  it('converts HH:MM to minutes', () => {
+    expect(toMinutes('01:30')).toBe(90);
+  });
+
+  it('converts minutes to HH:MM', () => {
+    expect(fromMinutes(75)).toBe('01:15');
+  });
+
+  it('calculates indicator', () => {
+    expect(diffIndicator(60, 60)).toBe('green');
+    expect(diffIndicator(60, 66)).toBe('yellow');
+    expect(diffIndicator(60, 80)).toBe('red');
   });
 });

--- a/verumoverview/frontend/src/__tests__/timeDiffIndicator.test.tsx
+++ b/verumoverview/frontend/src/__tests__/timeDiffIndicator.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import TimeDiffIndicator from '../components/modules/TimeDiffIndicator';
+
+test('indica verde quando gasto <= estimado', () => {
+  const { getByTestId } = render(<TimeDiffIndicator estimado={60} gasto={50} />);
+  expect(getByTestId('diff-indicator')).toHaveClass('bg-status-success');
+});
+
+test('indica amarelo quando dentro de 20%', () => {
+  const { getByTestId } = render(<TimeDiffIndicator estimado={60} gasto={70} />);
+  expect(getByTestId('diff-indicator')).toHaveClass('bg-status-warning');
+});
+
+test('indica vermelho quando acima de 20%', () => {
+  const { getByTestId } = render(<TimeDiffIndicator estimado={60} gasto={80} />);
+  expect(getByTestId('diff-indicator')).toHaveClass('bg-status-error');
+});

--- a/verumoverview/frontend/src/components/modules/TimeDiffIndicator.tsx
+++ b/verumoverview/frontend/src/components/modules/TimeDiffIndicator.tsx
@@ -1,0 +1,18 @@
+import { diffIndicator } from '../../utils/time';
+
+interface Props {
+  estimado: number;
+  gasto: number;
+}
+
+export default function TimeDiffIndicator({ estimado, gasto }: Props) {
+  const level = diffIndicator(estimado, gasto);
+  const color =
+    level === 'green'
+      ? 'bg-status-success'
+      : level === 'yellow'
+      ? 'bg-status-warning'
+      : 'bg-status-error';
+  const text = level === 'yellow' ? 'text-black' : 'text-white';
+  return <span data-testid="diff-indicator" className={`inline-block w-3 h-3 rounded-full ${color} ${text}`}></span>;
+}

--- a/verumoverview/frontend/src/components/ui/TimeInput.tsx
+++ b/verumoverview/frontend/src/components/ui/TimeInput.tsx
@@ -1,0 +1,20 @@
+import { InputHTMLAttributes } from 'react';
+import { minutesToTime, timeToMinutes } from '../../utils/time';
+
+interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export default function TimeInput({ value, onChange, className = '', ...props }: Props) {
+  const base = 'border p-2 rounded w-full focus:outline-none focus:ring-2 focus:ring-secondary';
+  return (
+    <input
+      type="time"
+      className={`${base} ${className}`}
+      value={minutesToTime(value)}
+      onChange={e => onChange(timeToMinutes(e.target.value))}
+      {...props}
+    />
+  );
+}

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -11,8 +11,11 @@ import { ToastContext } from '../hooks/ToastContext';
 import Skeleton from '../components/ui/Skeleton';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import TimeInput from '../components/ui/TimeInput';
 import Badge from '../components/ui/Badge';
 import { Table, THead, Th, Td } from '../components/ui/Table';
+import TimeDiffIndicator from '../components/modules/TimeDiffIndicator';
+import { minutesToTime } from '../utils/time';
 
 interface Activity {
   id_atividade: string;
@@ -20,6 +23,7 @@ interface Activity {
   status?: string;
   data_meta?: string;
   data_limite?: string;
+  /** minutos */
   horas_estimadas?: number;
   horas_gastas?: number;
   prioridade?: string;
@@ -133,7 +137,10 @@ export default function Atividades() {
                   </td>
                   <td className="p-2">{a.data_meta}</td>
                   <td className="p-2">{a.data_limite}</td>
-                  <td className="p-2">{a.horas_gastas || 0}/{a.horas_estimadas}</td>
+                  <td className="p-2 flex items-center gap-2">
+                    {minutesToTime(a.horas_gastas || 0)}/{minutesToTime(a.horas_estimadas || 0)}
+                    <TimeDiffIndicator estimado={a.horas_estimadas || 0} gasto={a.horas_gastas || 0} />
+                  </td>
                   <td className="p-2 space-x-2">
                     <button aria-label="Editar" className="text-blue-600" onClick={() => setEditing({ ...a })}>Editar</button>
                     <button aria-label="Excluir" className="text-red-600" onClick={() => handleDelete(a.id_atividade)}>Excluir</button>
@@ -196,20 +203,18 @@ export default function Atividades() {
           <div className="flex gap-2">
             <div className="flex-1">
               <label className="block">Horas Estimadas</label>
-              <Input
-                type="number"
-                className="p-1"
+              <TimeInput
                 value={editing.horas_estimadas || 0}
-                onChange={e => setEditing({ ...editing, horas_estimadas: Number(e.target.value) })}
+                onChange={v => setEditing({ ...editing, horas_estimadas: v })}
+                className="p-1"
               />
             </div>
             <div className="flex-1">
               <label className="block">Horas Gastas</label>
-              <Input
-                type="number"
-                className="p-1"
+              <TimeInput
                 value={editing.horas_gastas || 0}
-                onChange={e => setEditing({ ...editing, horas_gastas: Number(e.target.value) })}
+                onChange={v => setEditing({ ...editing, horas_gastas: v })}
+                className="p-1"
               />
             </div>
           </div>

--- a/verumoverview/frontend/src/utils/time.ts
+++ b/verumoverview/frontend/src/utils/time.ts
@@ -1,0 +1,23 @@
+export function minutesToTime(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(m)}`;
+}
+
+export function timeToMinutes(time: string): number {
+  if (!time) return 0;
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+export function diffIndicator(
+  estimado: number,
+  gasto: number
+): 'green' | 'yellow' | 'red' {
+  if (estimado === 0) return 'green';
+  const ratio = gasto / estimado;
+  if (ratio <= 1) return 'green';
+  if (ratio <= 1.2) return 'yellow';
+  return 'red';
+}

--- a/verumoverview/frontend/tsconfig.json
+++ b/verumoverview/frontend/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,
-    "lib": ["DOM", "ES2016"],
+    "lib": ["DOM", "ES2017"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Resumo
- cria utilitários para conversão de tempo em minutos no backend e frontend
- adiciona componente `TimeInput` e indicador de diferença de horas
- usa novos campos na página `Atividades`
- ajusta controladores de atividade e projeto
- acrescenta testes para utilidades de tempo e componente de semáforo

## Testes realizados
- `npm test` em `verumoverview/backend`
- `npm test` em `verumoverview/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6845f75448888321aeb10e9d0a4611af