### PR TITLE
Refatora formulário de atividades em modal

### DIFF
--- a/verumoverview/frontend/src/__tests__/modal.test.tsx
+++ b/verumoverview/frontend/src/__tests__/modal.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from '../components/modules/Modal';
+
+it('fecha ao pressionar Escape', async () => {
+  const onClose = jest.fn();
+  render(
+    <Modal isOpen={true} title="Teste" onClose={onClose}>
+      <div>Conteúdo</div>
+    </Modal>
+  );
+  await userEvent.keyboard('{Escape}');
+  expect(onClose).toHaveBeenCalled();
+});

--- a/verumoverview/frontend/src/components/modules/Modal.tsx
+++ b/verumoverview/frontend/src/components/modules/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface ModalProps {
   isOpen: boolean;
@@ -8,12 +8,30 @@ interface ModalProps {
 }
 
 export default function Modal({ isOpen, title, onClose, children }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    dialogRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-dark-background rounded shadow-lg w-full max-w-2xl p-4">
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        className="bg-white dark:bg-dark-background rounded shadow-lg w-full max-w-2xl p-4 outline-none"
+      >
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold">{title}</h2>
+          <h2 id="modal-title" className="text-lg font-semibold">{title}</h2>
           <button onClick={onClose} aria-label="Fechar" className="text-xl">×</button>
         </div>
         {children}

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -12,6 +12,7 @@ import Skeleton from '../components/ui/Skeleton';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Badge from '../components/ui/Badge';
+import Modal from '../components/modules/Modal';
 import { Table, THead, Th, Td } from '../components/ui/Table';
 
 interface Activity {
@@ -145,21 +146,22 @@ export default function Atividades() {
         )}
       </div>
 
-      {editing && (
-        <form onSubmit={handleSubmit} className="bg-white dark:bg-dark-background p-4 rounded shadow space-y-2">
+      <Modal isOpen={!!editing} title={editing?.id_atividade ? 'Editar Atividade' : 'Nova Atividade'} onClose={() => setEditing(null)}>
+        {editing && (
+        <form onSubmit={handleSubmit} className="space-y-2">
           <div>
             <label className="block">Título</label>
-          <Input
-            type="text"
-            className="p-1"
-            value={editing.titulo}
-            onChange={e => {
-              setEditing({ ...editing, titulo: e.target.value });
-              if (errors.titulo) setErrors({ ...errors, titulo: '' });
-            }}
-            required
-            error={errors.titulo}
-          />
+            <Input
+              type="text"
+              className="p-1"
+              value={editing.titulo}
+              onChange={e => {
+                setEditing({ ...editing, titulo: e.target.value });
+                if (errors.titulo) setErrors({ ...errors, titulo: '' });
+              }}
+              required
+              error={errors.titulo}
+            />
             {errors.titulo && <span className="error-message">{errors.titulo}</span>}
           </div>
           <div>
@@ -231,7 +233,8 @@ export default function Atividades() {
             </Button>
           </div>
         </form>
-      )}
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- reutiliza componente Modal nas atividades
- fecha modal com tecla Escape e adiciona acessibilidade
- cria teste para verificação do comportamento do modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845f7604fa48321b2ec10e9f7c02eb3