### PR TITLE
Atualiza prioridades e cores no design system

### DIFF
--- a/verumoverview/docs/design.md
+++ b/verumoverview/docs/design.md
@@ -12,8 +12,10 @@ A plataforma utiliza um design moderno, clean e visualmente atrativo. As interfa
 - **Vermelho:** `#D63031`
 
 ## Cores de Criticidade/Prioridade
-- **Alta:** `#E17055`
-- **Media:** `#FDCB6E`
+- **Emergencial:** `#D63031`
+- **Muito Alta:** `#E17055`
+- **Alta:** `#FDCB6E`
+- **Média:** `#00B894`
 - **Baixa:** `#0984E3`
 
 ## Cores para Indicadores e Insights

--- a/verumoverview/frontend/src/components/ui/Badge.tsx
+++ b/verumoverview/frontend/src/components/ui/Badge.tsx
@@ -10,9 +10,11 @@ const styles = {
     vermelho: 'bg-status-vermelho text-white'
   },
   prioridade: {
-    alta: 'bg-prioridade-alta text-white',
-    media: 'bg-prioridade-media text-black',
-    baixa: 'bg-prioridade-baixa text-white'
+    Emergencial: 'bg-[#D63031] text-white',
+    'Muito Alta': 'bg-[#E17055] text-white',
+    Alta: 'bg-[#FDCB6E] text-black',
+    Média: 'bg-[#00B894] text-white',
+    Baixa: 'bg-[#0984E3] text-white'
   },
   indicador: {
     positivo: 'bg-indicador-positivo text-white',

--- a/verumoverview/frontend/src/constants/design-tokens.js
+++ b/verumoverview/frontend/src/constants/design-tokens.js
@@ -9,10 +9,12 @@ const designTokens = {
       warning: '#FDCB6E',
       error: '#D63031'
     },
-    priority: {
-      high: '#E17055',
-      medium: '#FDCB6E',
-      low: '#0984E3'
+    prioridade: {
+      emergencial: '#D63031',
+      muitoAlta: '#E17055',
+      alta: '#FDCB6E',
+      media: '#00B894',
+      baixa: '#0984E3'
     },
     indicators: {
       positive: '#00CEC9',

--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -33,7 +33,7 @@ const emptyActivity: Activity = {
   data_limite: '',
   horas_estimadas: 0,
   horas_gastas: 0,
-  prioridade: 'Media'
+  prioridade: 'Média'
 };
 
 export default function Atividades() {
@@ -217,8 +217,10 @@ export default function Atividades() {
             <label className="block">Prioridade</label>
             <select className="border p-1 w-full rounded focus:outline-none focus:ring-2 focus:ring-secondary" value={editing.prioridade}
               onChange={e => setEditing({ ...editing, prioridade: e.target.value })}>
+              <option>Emergencial</option>
+              <option>Muito Alta</option>
               <option>Alta</option>
-              <option>Media</option>
+              <option>Média</option>
               <option>Baixa</option>
             </select>
           </div>

--- a/verumoverview/frontend/tailwind.config.js
+++ b/verumoverview/frontend/tailwind.config.js
@@ -12,7 +12,7 @@ export default {
         primaryDark: designTokens.colors.primaryDark,
         white: designTokens.colors.white,
         status: designTokens.colors.status,
-        priority: designTokens.colors.priority,
+        prioridade: designTokens.colors.prioridade,
         indicators: designTokens.colors.indicators,
         dark: designTokens.colors.dark,
         gray: designTokens.colors.gray


### PR DESCRIPTION
## Resumo
- corrige duplicidade de `Média` no `Badge`
- define escala de cores para todas as prioridades
- atualiza design tokens e Tailwind para refletir novas cores
- documenta as cores de prioridade no design system

## Testes
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845f74b2a188321a4abff9ac052e275