### PR TITLE
Corrige erro de build removendo import duplicado

### DIFF
--- a/verumoverview/frontend/src/pages/Atividades.tsx
+++ b/verumoverview/frontend/src/pages/Atividades.tsx
@@ -22,7 +22,6 @@ import Card from '../components/ui/Card';
 import { formatDate } from '../utils/date';
 import { DataTable, Column } from '../components/ui/Table';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
-import Modal from '../components/modules/Modal';
 import {
   fetchProjects,
   createProject,


### PR DESCRIPTION
## Summary
- remove import duplicado de `Modal` no componente Atividades

## Testing
- `npm test` dentro de `verumoverview/frontend` *(falhou: jest não encontrado)*
- `npm test` dentro de `verumoverview/backend` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684601ace5408321b8d3a0dc341167b3