### PR TITLE
Remove fallback do JWT_SECRET

### DIFF
--- a/verumoverview/README.md
+++ b/verumoverview/README.md
@@ -29,6 +29,7 @@ cp backend/.env.example backend/.env
 ```
 
 Edite as variáveis conforme sua configuração local.
+Defina a variável `JWT_SECRET` com a chave usada na assinatura dos tokens.
 Se precisar liberar origens diferentes da padrão para o CORS, ajuste `CORS_ORIGIN` em `.env`.
 
 ## Uso com Docker Compose

--- a/verumoverview/backend/src/controllers/AuthController.ts
+++ b/verumoverview/backend/src/controllers/AuthController.ts
@@ -24,9 +24,13 @@ export default class AuthController {
         res.status(401).json({ message: 'Credenciais inválidas' });
         return;
       }
+      const secret = process.env.JWT_SECRET;
+      if (!secret) {
+        throw new Error('JWT_SECRET não definido');
+      }
       const token = jwt.sign(
         { id: user.id, permissoes: user.permissoes },
-        process.env.JWT_SECRET || 'secret',
+        secret,
         { expiresIn: '1h' }
       );
       res.json({ token });


### PR DESCRIPTION
## Resumo
- exige que `JWT_SECRET` esteja definido em AuthController
- menciona no README a necessidade de configurar `JWT_SECRET` no backend

## Testes
- `npm test` em `verumoverview/backend` *(falha: JWT_SECRET não definido)*
- `npm test` em `verumoverview/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6846183682888321b513d044f95d39e3