### PR TITLE
Implementa filtros de campos nos controllers

### DIFF
--- a/verumoverview/backend/src/controllers/PersonController.ts
+++ b/verumoverview/backend/src/controllers/PersonController.ts
@@ -2,6 +2,20 @@ import { Request, Response } from 'express';
 import db from '../services/db';
 import { Person } from '../models/Person';
 
+const ALLOWED_FIELDS = [
+  'nome_completo',
+  'email',
+  'cargo_funcao',
+  'time',
+  'status',
+  'perfil_comportamental',
+  'engajamento',
+  'projetos_vinculados',
+  'anexos',
+  'historico_movimentacoes',
+  'comentarios'
+];
+
 export default class PersonController {
   static async list(req: Request, res: Response): Promise<void> {
     try {
@@ -30,6 +44,11 @@ export default class PersonController {
 
   static async create(req: Request, res: Response): Promise<void> {
     const fields = req.body as Person;
+    const invalid = Object.keys(fields).filter(k => !ALLOWED_FIELDS.includes(k));
+    if (invalid.length) {
+      res.status(400).json({ message: `Campos nao permitidos: ${invalid.join(', ')}` });
+      return;
+    }
     try {
       const result = await db.query(
         `INSERT INTO pessoas(
@@ -61,8 +80,13 @@ export default class PersonController {
   static async update(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
     const fields = req.body as Person;
-    const keys = Object.keys(fields);
-    const values = Object.values(fields);
+    const invalid = Object.keys(fields).filter(k => !ALLOWED_FIELDS.includes(k));
+    if (invalid.length) {
+      res.status(400).json({ message: `Campos nao permitidos: ${invalid.join(', ')}` });
+      return;
+    }
+    const keys = Object.keys(fields).filter(k => ALLOWED_FIELDS.includes(k));
+    const values = keys.map(k => (fields as any)[k]);
     const sets = keys.map((k, i) => `${k}=$${i + 1}`);
     try {
       const result = await db.query(

--- a/verumoverview/backend/src/controllers/TimeController.ts
+++ b/verumoverview/backend/src/controllers/TimeController.ts
@@ -2,6 +2,16 @@ import { Request, Response } from 'express';
 import db from '../services/db';
 import { Time } from '../models/Time';
 
+const ALLOWED_FIELDS = [
+  'nome',
+  'lider',
+  'capacidade_total',
+  'membros',
+  'anexos',
+  'historico_alteracoes',
+  'comentarios'
+];
+
 export default class TimeController {
   static async list(req: Request, res: Response): Promise<void> {
     try {
@@ -30,6 +40,11 @@ export default class TimeController {
 
   static async create(req: Request, res: Response): Promise<void> {
     const fields = req.body as Time;
+    const invalid = Object.keys(fields).filter(k => !ALLOWED_FIELDS.includes(k));
+    if (invalid.length) {
+      res.status(400).json({ message: `Campos nao permitidos: ${invalid.join(', ')}` });
+      return;
+    }
     try {
       const result = await db.query(
         `INSERT INTO times(
@@ -55,8 +70,13 @@ export default class TimeController {
   static async update(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
     const fields = req.body as Time;
-    const keys = Object.keys(fields);
-    const values = Object.values(fields);
+    const invalid = Object.keys(fields).filter(k => !ALLOWED_FIELDS.includes(k));
+    if (invalid.length) {
+      res.status(400).json({ message: `Campos nao permitidos: ${invalid.join(', ')}` });
+      return;
+    }
+    const keys = Object.keys(fields).filter(k => ALLOWED_FIELDS.includes(k));
+    const values = keys.map(k => (fields as any)[k]);
     const sets = keys.map((k, i) => `${k}=$${i + 1}`);
     try {
       const result = await db.query(


### PR DESCRIPTION
## Summary
- limita campos aceitos em cada controller de CRUD
- valida e rejeita campos inválidos

## Testing
- `npm test` em `verumoverview/backend`
- `npm test` em `verumoverview/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68461839b0c48321bbfa7cc5957eda67