### PR TITLE
Melhoria na gravação de logs

### DIFF
--- a/verumoverview/backend/src/middlewares/logMiddleware.ts
+++ b/verumoverview/backend/src/middlewares/logMiddleware.ts
@@ -1,9 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
 import db from '../services/db';
 
-export default function logMiddleware(req: Request, res: Response, next: NextFunction) {
+export default async function logMiddleware(req: Request, res: Response, next: NextFunction) {
   const user = (req as any).user?.id || 'anonymous';
   const logEntry = {
     user,
@@ -12,10 +12,27 @@ export default function logMiddleware(req: Request, res: Response, next: NextFun
     timestamp: new Date().toISOString()
   };
   const logsDir = path.join(__dirname, '../../logs');
-  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir);
-  fs.appendFileSync(path.join(logsDir, 'actions.log'), JSON.stringify(logEntry) + '\n');
+  const logFile = path.join(logsDir, 'actions.log');
   try {
-    db.query('INSERT INTO logs(usuario_id, acao, detalhes) VALUES($1,$2,$3)', [
+    await fs.mkdir(logsDir, { recursive: true });
+    try {
+      const { size } = await fs.stat(logFile);
+      const maxSize = 5 * 1024 * 1024; // 5MB
+      if (size >= maxSize) {
+        const rotated = path.join(logsDir, `actions-${Date.now()}.log`);
+        await fs.rename(logFile, rotated);
+      }
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') {
+        console.error('Failed to check log file size', err);
+      }
+    }
+    await fs.appendFile(logFile, JSON.stringify(logEntry) + '\n');
+  } catch (err) {
+    console.error('Failed to write log file', err);
+  }
+  try {
+    await db.query('INSERT INTO logs(usuario_id, acao, detalhes) VALUES($1,$2,$3)', [
       user === 'anonymous' ? null : Number(user),
       `${req.method} ${req.originalUrl}`,
       JSON.stringify(logEntry)


### PR DESCRIPTION
## Summary
- tornar logMiddleware assíncrono
- adicionar rotação de arquivo quando actions.log atinge 5 MB
- aguardar inserção na base de dados e tratar erros

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846183c5074832191752290035abd06